### PR TITLE
Add clipboard support for OS X.

### DIFF
--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -768,18 +768,36 @@ static void copy_to_xclip(void)
     FILE *pfile = NULL;
     string line;
 
-    if ((pfile = popen("xclip -i > /dev/null 2>&1", "w")) == NULL || //Linux
-        (pfile = popen("pbcopy > /dev/null 2>&1", "w")) == NULL) { //Mac
-	flash();
-	return;
+    //XXX : Check if this is linux or MAC. Probably not the best solution but
+    //better than traversing the PATH to stat for the binaries or trying to
+    //forkexec.
+   if ( (pfile = popen("xclip -i > /dev/null 2>&1", "w")) != NULL &&
+         pclose(pfile) == 0) {
+       pfile = popen("xclip -i > /dev/null 2>&1", "w");
+   }
+   else {
+       pfile = NULL;
+   }
+
+   if ( !pfile && (pfile = popen("pbcopy > /dev/null 2>&1", "w")) != NULL &&
+         pclose(pfile) == 0) {
+       pfile = popen("pbcopy > /dev/null 2>&1", "w");
+   }
+   else {
+       pfile = NULL;
+   }
+
+   if (!pfile) {
+        flash();
+        return;
     }
 
     for (iter = bv.begin(); iter != bv.end(); iter++) {
-	tc->grep_value_for_line(*iter, line);
-	fprintf(pfile, "%s\n", line.c_str());
+        tc->grep_value_for_line(*iter, line);
+        fprintf(pfile, "%s\n", line.c_str());
     }
 
-    fclose(pfile);
+    pclose(pfile);
     pfile = NULL;
 }
 


### PR DESCRIPTION
1. Use pbcopy to add support for copying to pasteboard on OS X.
2. Redirect both, STDOUT and STDERR to /dev/null

Tested with Snow Leopard.
