### PR TITLE
Fix the static linking issue. fixes tstack/lnav#71.

### DIFF
--- a/configure
+++ b/configure
@@ -3190,7 +3190,7 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
 
-for defdir in /opt/local /usr/local /usr; do
+for defdir in /opt/local /usr/local /usr /; do
     if test -d "$defdir/include"; then
         CPPFLAGS="$CPPFLAGS -I$defdir/include"
     fi
@@ -3200,6 +3200,10 @@ for defdir in /opt/local /usr/local /usr; do
     fi
     if test -d "$defdir/lib64"; then
         LDFLAGS="$LDFLAGS -L$defdir/lib64"
+    fi
+
+    if test -d "$defdir/lib/x86_64-linux-gnu"; then
+        LDFLAGS="$LDFLAGS -L$defdir/lib/x86_64-linux-gnu"
     fi
 done
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_PREFIX_DEFAULT(/usr/)
 
 AC_CANONICAL_HOST
 
-for defdir in /opt/local /usr/local /usr; do
+for defdir in /opt/local /usr/local /usr /; do
     if test -d "$defdir/include"; then
         CPPFLAGS="$CPPFLAGS -I$defdir/include"
     fi
@@ -18,6 +18,10 @@ for defdir in /opt/local /usr/local /usr; do
     fi
     if test -d "$defdir/lib64"; then
         LDFLAGS="$LDFLAGS -L$defdir/lib64"
+    fi
+
+    if test -d "$defdir/lib/x86_64-linux-gnu"; then
+        LDFLAGS="$LDFLAGS -L$defdir/lib/x86_64-linux-gnu"
     fi
 done
 


### PR DESCRIPTION
Would you be OK if I added libgpm and libtinfo to the list of static_lib_list. I also noticed that I should probably remove the references to libcrypto from the static_lib_list as well, since it's not used for the SHA-1 hashes. I could roll both of them in to a single change.
