### PR TITLE
Static linking related cleanup.

### DIFF
--- a/configure
+++ b/configure
@@ -7262,8 +7262,9 @@ esac
 
 ALL_LDFLAGS="$LDFLAGS $SQLITE3_LDFLAGS"
 
-static_lib_list="libncurses.a libreadline.a libsqlite3.a libz.a libcrypto.a"
+static_lib_list="libncurses.a libreadline.a libsqlite3.a libz.a libtinfo.a"
 static_lib_list="$static_lib_list libpcre.a libpcrecpp.a libncursesw.a libbz2.a"
+static_lib_list="$static_lib_list libgpm.a"
 
 # Check whether --enable-static was given.
 if test "${enable_static+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -108,8 +108,9 @@ esac
 
 ALL_LDFLAGS="$LDFLAGS $SQLITE3_LDFLAGS"
 
-static_lib_list="libncurses.a libreadline.a libsqlite3.a libz.a libcrypto.a"
+static_lib_list="libncurses.a libreadline.a libsqlite3.a libz.a libtinfo.a"
 static_lib_list="$static_lib_list libpcre.a libpcrecpp.a libncursesw.a libbz2.a"
+static_lib_list="$static_lib_list libgpm.a"
 
 AC_ARG_ENABLE([static],
               AS_HELP_STRING([--disable-static],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,8 +35,7 @@ LDADD = \
 	$(READLINE_LIBS) \
 	$(CURSES_LIB) \
 	$(SQLITE3_LIBS) \
-	-lpcrecpp \
-	-lcrypto
+	-lpcrecpp
 
 dist_noinst_DATA = \
 	default-log-formats.json \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -361,8 +361,7 @@ LDADD = \
 	$(READLINE_LIBS) \
 	$(CURSES_LIB) \
 	$(SQLITE3_LIBS) \
-	-lpcrecpp \
-	-lcrypto
+	-lpcrecpp
 
 dist_noinst_DATA = \
 	default-log-formats.json \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -67,7 +67,7 @@ test_pcrepp_SOURCES = test_pcrepp.cc
 test_pcrepp_LDADD = ../src/libdiag.a $(PCRE_LIBS) -lz
 
 test_top_status_SOURCES = test_top_status.cc
-test_top_status_LDADD = ../src/libdiag.a -lcrypto $(CURSES_LIB) $(PCRE_LIBS) $(SQLITE3_LIBS) -lz
+test_top_status_LDADD = ../src/libdiag.a $(CURSES_LIB) $(PCRE_LIBS) $(SQLITE3_LIBS) -lz
 
 test_yajlpp_SOURCES = test_yajlpp.cc
 test_yajlpp_LDADD = ../src/libdiag.a
@@ -84,14 +84,13 @@ drive_listview_LDADD = ../src/libdiag.a $(CURSES_LIB) -lz
 drive_logfile_SOURCES = drive_logfile.cc
 drive_logfile_LDADD = \
 	../src/libdiag.a \
-	-lcrypto \
 	$(CURSES_LIB) \
 	$(SQLITE3_LIBS) \
 	$(PCRE_LIBS) \
 	-lpcrecpp
 
 drive_sequencer_SOURCES = drive_sequencer.cc
-drive_sequencer_LDADD = ../src/libdiag.a -lcrypto $(CURSES_LIB) $(SQLITE3_LIBS)
+drive_sequencer_LDADD = ../src/libdiag.a $(CURSES_LIB) $(SQLITE3_LIBS)
 
 drive_data_scanner_SOURCES = \
 	drive_data_scanner.cc
@@ -99,7 +98,6 @@ drive_data_scanner_LDADD = \
 	../src/libdiag.a \
 	../src/default-log-formats-json.o \
 	../src/dump-pid-sh.o \
-	-lcrypto \
 	$(PCRE_LIBS) \
 	$(SQLITE3_LIBS) \
 	-lpcrecpp \
@@ -122,8 +120,7 @@ drive_sql_LDADD = \
 	$(PCRE_LIBS) \
 	$(CURSES_LIB) \
 	$(READLINE_LIBS) \
-	-lpcrecpp \
-	-lcrypto
+	-lpcrecpp
 
 slicer_SOURCES = slicer.cc
 slicer_LDADD = ../src/libdiag.a

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -631,7 +631,7 @@ test_line_buffer2_LDADD = ../src/libdiag.a
 test_pcrepp_SOURCES = test_pcrepp.cc
 test_pcrepp_LDADD = ../src/libdiag.a $(PCRE_LIBS) -lz
 test_top_status_SOURCES = test_top_status.cc
-test_top_status_LDADD = ../src/libdiag.a -lcrypto $(CURSES_LIB) $(PCRE_LIBS) $(SQLITE3_LIBS) -lz
+test_top_status_LDADD = ../src/libdiag.a $(CURSES_LIB) $(PCRE_LIBS) $(SQLITE3_LIBS) -lz
 test_yajlpp_SOURCES = test_yajlpp.cc
 test_yajlpp_LDADD = ../src/libdiag.a
 drive_line_buffer_SOURCES = drive_line_buffer.cc
@@ -643,14 +643,13 @@ drive_listview_LDADD = ../src/libdiag.a $(CURSES_LIB) -lz
 drive_logfile_SOURCES = drive_logfile.cc
 drive_logfile_LDADD = \
 	../src/libdiag.a \
-	-lcrypto \
 	$(CURSES_LIB) \
 	$(SQLITE3_LIBS) \
 	$(PCRE_LIBS) \
 	-lpcrecpp
 
 drive_sequencer_SOURCES = drive_sequencer.cc
-drive_sequencer_LDADD = ../src/libdiag.a -lcrypto $(CURSES_LIB) $(SQLITE3_LIBS)
+drive_sequencer_LDADD = ../src/libdiag.a $(CURSES_LIB) $(SQLITE3_LIBS)
 drive_data_scanner_SOURCES = \
 	drive_data_scanner.cc
 
@@ -658,7 +657,6 @@ drive_data_scanner_LDADD = \
 	../src/libdiag.a \
 	../src/default-log-formats-json.o \
 	../src/dump-pid-sh.o \
-	-lcrypto \
 	$(PCRE_LIBS) \
 	$(SQLITE3_LIBS) \
 	-lpcrecpp \
@@ -679,8 +677,7 @@ drive_sql_LDADD = \
 	$(PCRE_LIBS) \
 	$(CURSES_LIB) \
 	$(READLINE_LIBS) \
-	-lpcrecpp \
-	-lcrypto
+	-lpcrecpp
 
 slicer_SOURCES = slicer.cc
 slicer_LDADD = ../src/libdiag.a


### PR DESCRIPTION
- Remove traces of libcrypto, since we don't use OpenSSL anymore.
- Add libgpm and libtinfo to the list of static_lib_list.
