### PR TITLE
Convert byte encoding to host byte order

### DIFF
--- a/src/line_buffer.cc
+++ b/src/line_buffer.cc
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <endian.h>
 
 #ifdef HAVE_BZLIB_H
 #include <bzlib.h>
@@ -182,7 +183,7 @@ throw (error)
                             throw error(errno);
                         }
                     }
-                    this->lb_file_time = *((int32_t *)&gz_id[4]);
+                    this->lb_file_time = le32toh(*((int32_t *)&gz_id[4]));
                     if (this->lb_file_time < 0)
                         this->lb_file_time = 0;
                     this->lb_gz_offset = lseek(this->lb_fd, 0, SEEK_CUR);


### PR DESCRIPTION
Correctly convert byte encoding for 32bit value from little-endian order
to host byte order.
