### PR TITLE
Reduce session_data filesize and some minor cleanup.

### DIFF
--- a/src/session_data.cc
+++ b/src/session_data.cc
@@ -1183,7 +1183,6 @@ void save_session(void)
         perror("Unable to create yajl_gen object");
     }
     else {
-        yajl_gen_config(handle, yajl_gen_beautify, 1);
         yajl_gen_config(handle,
                         yajl_gen_print_callback, yajl_writer, file.in());
 
@@ -1274,10 +1273,6 @@ void save_session(void)
             }
 
             root_map.gen("commands");
-
-            {
-
-            }
         }
 
         yajl_gen_clear(handle);


### PR DESCRIPTION
After a year of not cleaning up the '~/.lnav' folder, the folder was
consuming ~8Mb of disk space. This change tries to reduce the disk
consumption by the session_data files.
- The json data in the session_data is beautified. The extra characters
  contribute to some of the file size. After removing the beautification
  option, the file size reduces by 60-20%, depending on how many files
  are open.
  
  Without knowing much about the functionality of these files, my
  cursory tests seem to show that lnav can still restore the sessions
  after this change. I don't know if these files are meant for human
  consumption or not but they can easily be run through a linter to
  beautify them again.
- While I was in the file, I noticed that there was a scope declared
  with no code inside it. Seems like a remnant of a cleanup.
