### PR TITLE
[vmw_log] 'panic' is an 'error' too.

### DIFF
--- a/src/default-log-formats.json
+++ b/src/default-log-formats.json
@@ -680,7 +680,7 @@
         },
         "level-field": "level",
         "level" : {
-            "error" : "error",
+            "error" : "(error|panic)",
             "warning" : "warning",
             "trace" : "verbose"
             },


### PR DESCRIPTION
VPXD prints out the stackframes in the log files when it terminates
abnormally. These log messages have a log level of 'panic'. I guess
these qualify as 'error' as well.
