### PR TITLE
[log_accel] Minor refactoring.

### DIFF
--- a/src/log_accel.hh
+++ b/src/log_accel.hh
@@ -107,9 +107,8 @@ public:
 
         range = std::max(range, MIN_RANGE);
         for (int lpc = 0; lpc < (this->la_velocity_size - 1); lpc++) {
-            double accel = (
-                (this->la_velocity[lpc] - this->la_min_velocity) / range -
-                (this->la_velocity[lpc + 1] - this->la_min_velocity) / range);
+            double accel =
+                (this->la_velocity[lpc] - this->la_velocity[lpc + 1]) / range;
             total_accel += accel;
         }
 


### PR DESCRIPTION
Unless I am misunderstanding the intention behind the equation:

```
(A - D)/C - (B - D)/C = (A - B)/C
```

The output seems to be exactly the same:

```
Before:
=======
 1m7s000│Nov 11 06:45:01 XXX-XXX CRON[28452]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
11m7s000│Nov 11 06:55:01 XXX-XXX CRON[28819]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
21m7s000│Nov 11 07:05:01 XXX-XXX CRON[29186]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
31m7s000│Nov 11 07:15:01 XXX-XXX CRON[29552]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
33m7s000│Nov 11 07:17:01 XXX-XXX CRON[29629]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)
41m7s000│Nov 11 07:25:01 XXX-XXX CRON[29922]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
51m7s000│Nov 11 07:35:01 XXX-XXX CRON[30290]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
```

   1h1m7s000│Nov 11 07:45:01 XXX-XXX CRON[30657]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)

```
After:
======
 1m7s000│Nov 11 06:45:01 XXX-XXX CRON[28452]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
11m7s000│Nov 11 06:55:01 XXX-XXX CRON[28819]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
21m7s000│Nov 11 07:05:01 XXX-XXX CRON[29186]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
31m7s000│Nov 11 07:15:01 XXX-XXX CRON[29552]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
33m7s000│Nov 11 07:17:01 XXX-XXX CRON[29629]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)
41m7s000│Nov 11 07:25:01 XXX-XXX CRON[29922]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
51m7s000│Nov 11 07:35:01 XXX-XXX CRON[30290]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
```

   1h1m7s000│Nov 11 07:45:01 XXX-XXX CRON[30657]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)

Some names and identifying details in the log snippets above have been changed
to protect the privacy of individuals. Any resemblance to actual computers,
sentient or otherwisei, is purely coincidental.
