### PR TITLE
Partial fix for issue#53 (Allow the use of yajl installed on the system)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,6 +95,8 @@ AC_CHECK_HEADERS(execinfo.h pty.h util.h zlib.h bzlib.h libutil.h sys/ttydefault
 
 LNAV_WITH_JEMALLOC
 
+LNAV_WITH_LOCAL_YAJL
+
 AX_WITH_CURSES
 
 if test "x$ax_cv_curses" != xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -166,6 +166,8 @@ if test x"${enable_static}" != x"no"; then
 fi
 AC_SUBST(STATIC_LDFLAGS)
 
+AM_CONDITIONAL(USE_INCLUDED_YAJL, test $HAVE_LOCAL_YAJL -eq 0)
+
 AC_CONFIG_HEADERS([src/config.h])
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([TESTS_ENVIRONMENT])

--- a/m4/lnav_common.m4
+++ b/m4/lnav_common.m4
@@ -1,0 +1,22 @@
+AC_DEFUN([LNAV_ADDTO], [
+  if test "x$$1" = "x"; then
+    test "x$verbose" = "xyes" && echo "  setting $1 to \"$2\""
+    $1="$2"
+  else
+    ats_addto_bugger="$2"
+    for i in $ats_addto_bugger; do
+      ats_addto_duplicate="0"
+      for j in $$1; do
+        if test "x$i" = "x$j"; then
+          ats_addto_duplicate="1"
+          break
+        fi
+      done
+      if test $ats_addto_duplicate = "0"; then
+        test "x$verbose" = "xyes" && echo "  adding \"$i\" to $1"
+        $1="$$1 $i"
+      fi
+    done
+  fi
+])dnl
+

--- a/m4/lnav_with_jemalloc.m4
+++ b/m4/lnav_with_jemalloc.m4
@@ -18,28 +18,6 @@ dnl
 dnl lnav_with_jemalloc.m4: lnav's jemalloc autoconf macros
 dnl
 dnl
-AC_DEFUN([LNAV_ADDTO], [
-  if test "x$$1" = "x"; then
-    test "x$verbose" = "xyes" && echo "  setting $1 to \"$2\""
-    $1="$2"
-  else
-    ats_addto_bugger="$2"
-    for i in $ats_addto_bugger; do
-      ats_addto_duplicate="0"
-      for j in $$1; do
-        if test "x$i" = "x$j"; then
-          ats_addto_duplicate="1"
-          break
-        fi
-      done
-      if test $ats_addto_duplicate = "0"; then
-        test "x$verbose" = "xyes" && echo "  adding \"$i\" to $1"
-        $1="$$1 $i"
-      fi
-    done
-  fi
-])dnl
-
 AC_DEFUN([LNAV_WITH_JEMALLOC], [
 enable_jemalloc=no
 AC_ARG_WITH([jemalloc], [AC_HELP_STRING([--with-jemalloc=DIR], [use a specific jemalloc library])],

--- a/m4/lnav_with_yajl.m4
+++ b/m4/lnav_with_yajl.m4
@@ -1,0 +1,69 @@
+AC_DEFUN([LNAV_WITH_LOCAL_YAJL],
+[
+ENABLE_LOCAL_YAJL="no"
+ AC_ARG_WITH([yajl],
+    AC_HELP_STRING(
+        [--with-yajl=DIR],
+        [use a local installed version of yajl]
+    ),
+    [
+    if test "$withval" != "no"; then
+        ENABLE_LOCAL_YAJL="yes"
+        modify_env_variables="no"
+        case "$withval" in
+            yes)
+                AC_MSG_NOTICE([Checking for yajl libs])
+                ;;
+            *)
+                yajl_include="$withval/include"
+                yajl_ldflags="$withval/lib"
+                modify_env_variables="yes"
+                AC_MSG_NOTICE([Checking for yajl libs in $withval])
+                ;;
+        esac
+    fi
+    ]
+)
+
+HAVE_LOCAL_YAJL=0
+YAJL_HAVE_LOCAL_HEADERS=0
+YAJL_HAVE_LOCAL_LIBS=0
+if test "$ENABLE_LOCAL_YAJL" != "no"; then
+    saved_ldflags=$LDFLAGS
+    saved_cppflags=$CPPFLAGS
+    saved_libtool_link_flags=$LIBTOOL_LIBK_FLAGS
+
+    if test "$modify_env_variables" != "no"; then
+        LNAV_ADDTO(CPPFLAGS, [-I${yajl_include}])
+        LNAV_ADDTO(LDFLAGS, [-L${yajl_ldflags}])
+        LNAV_ADDTO(LIBTOOL_LINK_FLAGS, [-R${yajl_ldflags}])
+    fi
+
+    AC_SEARCH_LIBS([yajl_gen_alloc], [yajl], [YAJL_HAVE_LOCAL_LIBS=1])
+
+    if test "$YAJL_HAVE_LOCAL_LIBS" != "0"; then
+        AC_MSG_NOTICE([Checking for yajl headers])
+        AC_CHECK_HEADERS([yajl/yajl_parse.h], [YAJL_HAVE_LOCAL_HEADERS=1])
+
+        if test "$YAJL_HAVE_LOCAL_HEADERS" != "0"; then
+            HAVE_LOCAL_YAJL=1
+            LNAV_ADDTO(LIBS, [-lyajl])
+        else
+            AC_MSG_WARN([yajl not found on the local system])
+        fi
+
+        if test "$HAVE_LOCAL_YAJL" = "0"; then
+            CPPFLAGS=$saved_cppflags
+            LDFLAGS=$saved_ldflags
+            LIBTOOL_LIBK_FLAGS=$saved_libtool_link_flags
+        fi
+    fi
+fi
+
+if test "$HAVE_LOCAL_YAJL" = "0"; then
+    AC_MSG_NOTICE([compiling with the included version of yajl])
+fi
+
+AC_SUBST(HAVE_LOCAL_YAJL)
+
+])dnl

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,7 +137,10 @@ noinst_HEADERS = \
 	log_format_impls.cc \
 	xterm_mouse.hh \
 	yajlpp.hh \
-	yajl/api/yajl_common.h \
+	spookyhash/SpookyV2.h
+
+if USE_INCLUDED_YAJL
+noinst_HEADERS += yajl/api/yajl_common.h \
 	yajl/api/yajl_gen.h \
 	yajl/api/yajl_parse.h \
 	yajl/api/yajl_tree.h \
@@ -148,8 +151,9 @@ noinst_HEADERS = \
 	yajl/yajl_encode.h \
 	yajl/yajl_lex.h \
 	yajl/yajl_parser.h \
-	yajl/yajl_version.h \
-	spookyhash/SpookyV2.h
+	yajl/yajl_version.h
+endif
+
 
 libdiag_a_SOURCES = \
 	ansi_scrubber.cc \
@@ -201,7 +205,10 @@ libdiag_a_SOURCES = \
 	log_vtab_impl.cc \
 	xterm_mouse.cc \
 	yajlpp.cc \
-	yajl/yajl.c \
+	spookyhash/SpookyV2.cpp
+
+if USE_INCLUDED_YAJL
+libdiag_a_SOURCES += yajl/yajl.c \
 	yajl/yajl_alloc.c \
 	yajl/yajl_alloc.h \
 	yajl/yajl_buf.c \
@@ -215,8 +222,9 @@ libdiag_a_SOURCES = \
 	yajl/yajl_parser.c \
 	yajl/yajl_parser.h \
 	yajl/yajl_tree.c \
-	yajl/yajl_version.c \
-	spookyhash/SpookyV2.cpp
+	yajl/yajl_version.c
+endif
+
 
 dist_noinst_SCRIPTS = \
 	init_sql.py


### PR DESCRIPTION
This should take care of the build related stuff required for compiling with the local yajl installed on the system. However, it seems like you have an extra method 'yajl_reset' added to the yajl codebase which is not in the upstream yajl codebase. The code will still have to be refactored to successfully compile against the local copy.