### PR TITLE
[build] Make sure readline has the necessary symbols.

### DIFF
--- a/m4/lnav_with_readline.m4
+++ b/m4/lnav_with_readline.m4
@@ -27,7 +27,10 @@ AC_DEFUN([AX_PATH_LIB_READLINE],
             AC_MSG_ERROR([readline library not found])
         )dnl
         AS_VAR_SET([READLINE_CFLAGS], ["-I$with_readline/include"])
+        AS_VAR_SET([READLINE_SAVED_LDFLAGS], ["$LDFLAGS"])
         LNAV_ADDTO(CPPFLAGS, ["-I$with_readline/include"])
+        dnl We want the provided path to be the first in the search order.
+        LDFLAGS="-L$with_readline/lib $LDFLAGS"
         ]dnl
     )
 
@@ -41,6 +44,18 @@ AC_DEFUN([AX_PATH_LIB_READLINE],
 
     AS_VAR_SET_IF([HAVE_READLINE_HEADERS], [],
         [AC_MSG_ERROR([readline headers not found])]
+    )
+
+    dnl Ensure that the readline library has the required symbols.
+    dnl i.e. We haven't picked up editline.
+    AC_SEARCH_LIBS([history_set_history_state], [readline],
+        [
+        AS_VAR_SET_IF([READLINE_SAVED_LDFLAGS],
+            AS_VAR_SET([LDFLAGS], ["$READLINE_SAVED_LDFLAGS"])
+        )
+        ],
+        AC_MSG_ERROR([libreadline does not have the required symbols. editline possibly masquerading as readline.])
+        [$CURSES]
     )
 
     AC_SUBST([READLINE_LIBS])


### PR DESCRIPTION
On FreeBSD variants, readline functionality is provided by editline which
is almost compatible but not quite. We could do a specific check for
editline but if editline adds the functionality in the future, this
check will still continue to fail. Instead look for one of the symbols
currently missing in editline as a sanity check.