### PR TITLE
Remove the check for libreadline.a

### DIFF
--- a/m4/lnav_with_readline.m4
+++ b/m4/lnav_with_readline.m4
@@ -14,25 +14,20 @@ AC_DEFUN([AX_PATH_LIB_READLINE],
         [no],
         AC_MSG_ERROR([readline required to build]),
         [yes],
+        [],
         [dnl
-        AC_SEARCH_LIBS([readline], [readline],
-            [AS_VAR_SET([READLINE_LIBS], ["-lreadline"])],
-            [AC_MSG_ERROR([libreadline library not found])],
-            [$CURSES_LIB]
-        )dnl
-        ],
-        [dnl
-        AS_VAR_SET([READLINE_LIBS], ["$with_readline/lib/libreadline.a"])
-        AC_CHECK_FILE("$READLINE_LIBS", [],
-            AC_MSG_ERROR([readline library not found])
-        )dnl
         AS_VAR_SET([READLINE_CFLAGS], ["-I$with_readline/include"])
-        AS_VAR_SET([READLINE_SAVED_LDFLAGS], ["$LDFLAGS"])
         LNAV_ADDTO(CPPFLAGS, ["-I$with_readline/include"])
         dnl We want the provided path to be the first in the search order.
         LDFLAGS="-L$with_readline/lib $LDFLAGS"
         ]dnl
     )
+
+    AC_SEARCH_LIBS([readline], [readline],
+        [AS_VAR_SET([READLINE_LIBS], ["-lreadline"])],
+        [AC_MSG_ERROR([libreadline library not found])],
+        [$CURSES_LIB]
+    )dnl
 
     AC_CHECK_HEADERS([readline.h readline/readline.h],
         [dnl
@@ -49,11 +44,7 @@ AC_DEFUN([AX_PATH_LIB_READLINE],
     dnl Ensure that the readline library has the required symbols.
     dnl i.e. We haven't picked up editline.
     AC_SEARCH_LIBS([history_set_history_state], [readline],
-        [
-        AS_VAR_SET_IF([READLINE_SAVED_LDFLAGS],
-            AS_VAR_SET([LDFLAGS], ["$READLINE_SAVED_LDFLAGS"])
-        )
-        ],
+        [],
         AC_MSG_ERROR([libreadline does not have the required symbols. editline possibly masquerading as readline.])
         [$CURSES]
     )


### PR DESCRIPTION
Do a standard check for libreadline and use '-lreadline' as usual.