### PR TITLE
Dead code and unused link flag removal.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,8 +47,7 @@ time_fmts.cc: ptimec
 AM_LDFLAGS = \
 	$(STATIC_LDFLAGS) \
 	$(SQLITE3_LDFLAGS) \
-	$(PCRE_LDFLAGS) \
-	-pthread
+	$(PCRE_LDFLAGS)
 
 AM_CPPFLAGS = \
 	-DSYSCONFDIR='"$(sysconfdir)"' \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -477,8 +477,7 @@ TIME_FORMATS = \
 AM_LDFLAGS = \
 	$(STATIC_LDFLAGS) \
 	$(SQLITE3_LDFLAGS) \
-	$(PCRE_LDFLAGS) \
-	-pthread
+	$(PCRE_LDFLAGS)
 
 AM_CPPFLAGS = \
 	-DSYSCONFDIR='"$(sysconfdir)"' \

--- a/src/log_format.cc
+++ b/src/log_format.cc
@@ -79,11 +79,6 @@ const char *logline::level_names[LEVEL__MAX + 1] = {
 static pcrepp LEVEL_RE(
         "(?i)(TRACE|VERBOSE|DEBUG|INFO|WARN(?:ING)?|ERROR|CRITICAL|SEVERE|FATAL)");
 
-static int strncasestr_i(const char *s1, const char *s2, size_t len)
-{
-    return strcasestr(s1, s2) == NULL;
-}
-
 logline::level_t logline::string2level(const char *levelstr, ssize_t len, bool exact)
 {
     logline::level_t retval = logline::LEVEL_UNKNOWN;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -47,8 +47,7 @@ check_PROGRAMS = \
 
 AM_LDFLAGS = \
 	$(STATIC_LDFLAGS) \
-	$(SQLITE3_LDFLAGS) \
-	-pthread
+	$(SQLITE3_LDFLAGS)
 
 LDADD = -lz
 

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -671,8 +671,7 @@ AM_CPPFLAGS = \
 
 AM_LDFLAGS = \
 	$(STATIC_LDFLAGS) \
-	$(SQLITE3_LDFLAGS) \
-	-pthread
+	$(SQLITE3_LDFLAGS)
 
 LDADD = -lz
 test_ansi_scrubber_SOURCES = test_ansi_scrubber.cc


### PR DESCRIPTION
This removes some (what I think is) dead code and unused linker flags. This change along with the previous changes pretty much clears out all the compiler warnings on OS X while compiling with Clang.