### PR TITLE
Minor changes.

### DIFF
--- a/src/environ_vtab.cc
+++ b/src/environ_vtab.cc
@@ -212,7 +212,7 @@ static int vt_update(sqlite3_vtab *tab,
     const char *name = (
         argc > 2 ? (const char *)sqlite3_value_text(argv[2]) : NULL);
     vtab *p_vt = (vtab *)tab;
-    int retval;
+    int retval = SQLITE_ERROR;
 
     if (argc != 1 &&
         (argc < 3 ||

--- a/src/readline_curses.cc
+++ b/src/readline_curses.cc
@@ -589,7 +589,7 @@ void readline_curses::start(void)
 void readline_curses::line_ready(const char *line)
 {
     auto_mem<char> expanded;
-    char           msg[1024];
+    char           msg[1024] = {0};
     int            rc;
 
     if (rl_line_buffer[0] == '^') {


### PR DESCRIPTION
Minor changes to stop Coverity from complaining. I am not sure what is the correct way to initialize an array in C++11 and whether we actually care.