### PR TITLE
[segfault] Fix a segfault while advancing map iters.

### DIFF
--- a/src/hist_source.cc
+++ b/src/hist_source.cc
@@ -73,7 +73,9 @@ void hist_source::text_value_for_line(textview_curses &tc,
 
         bucket_index          = brow - 1;
         group_iter = this->hs_groups.begin();
-        advance(group_iter, grow);
+        size_t groups_size = (size_t)this->hs_groups.size();
+        advance(group_iter,
+                (groups_size >= (size_t)grow) ? grow : groups_size);
         this->hs_token_bucket = &(group_iter->second[bucket_index]);
         if (this->hs_label_source != NULL) {
             this->hs_label_source->
@@ -102,7 +104,9 @@ void hist_source::text_attrs_for_line(textview_curses &tc,
         struct line_range  lr;
 
         group_iter = this->hs_groups.begin();
-        advance(group_iter, grow);
+        size_t groups_size = (size_t)this->hs_groups.size();
+        advance(group_iter,
+                (groups_size >= (size_t)grow) ? grow : groups_size);
 
         tc.get_dimensions(height, width);
         avail_width = width - this->hs_token_bucket->size();

--- a/src/hist_source.hh
+++ b/src/hist_source.hh
@@ -163,7 +163,9 @@ public:
             std::map<bucket_group_t, bucket_array_t>::const_iterator iter;
 
             iter = this->hs_groups.begin();
-            std::advance(iter, grow);
+            size_t groups_size = (size_t)this->hs_groups.size();
+            std::advance(iter,
+                (groups_size >= (size_t)grow) ? grow : groups_size);
 
             bucket_group_t bg = iter->first;
 


### PR DESCRIPTION
Advancing map iterators beyond it's size leads to a segfault. Avoid this
by advancing the iterator only as far as the size if offset is greater
than the size. I usually see this while re-opening a previously opened
file and trying to see the histogram after moving around for a while.

This seems to fix the crash and does the present the histogram.

__I don't think I completely understand what exactly is going on in these
files. I am just relying on the backtrace from the segfault.__