### PR TITLE
[build] Warn if libgpm is missing and other minor changes.

### DIFF
--- a/configure
+++ b/configure
@@ -3288,11 +3288,11 @@ done
 
 case x$srcdir in
 x/*)
-	abssrcdir=$srcdir
-	;;
+    abssrcdir=$srcdir
+    ;;
 *)
-	abssrcdir=`pwd`/$srcdir
-	;;
+    abssrcdir=`pwd`/$srcdir
+    ;;
 esac
 
 
@@ -4009,11 +4009,11 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking gprof(4) profiling support" >&5
 $as_echo_n "checking gprof(4) profiling support... " >&6; }
 if test x"${enable_profiling}" = x"yes" ; then
-	CFLAGS="$CFLAGS -pg -gstabs"
-	CXXFLAGS="$CXXFLAGS -pg -gstabs"
-	LDFLAGS="$LDFLAGS -pg"
+    CFLAGS="$CFLAGS -pg -gstabs"
+    CXXFLAGS="$CXXFLAGS -pg -gstabs"
+    LDFLAGS="$LDFLAGS -pg"
 else
-	enable_profiling=no
+    enable_profiling=no
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_profiling" >&5
 $as_echo "$enable_profiling" >&6; }
@@ -6162,7 +6162,11 @@ $as_echo "$as_me: Building with tinfo linking disabled" >&6;}
 
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing Gpm_Open" >&5
+case "$host_os" in #(
+  darwin*) :
+     ;; #(
+  *) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing Gpm_Open" >&5
 $as_echo_n "checking for library containing Gpm_Open... " >&6; }
 if ${ac_cv_search_Gpm_Open+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -6216,8 +6220,15 @@ ac_res=$ac_cv_search_Gpm_Open
 if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
+else
+          { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: libgpm not found. If build fails later consider installing gpm dev package        " >&5
+$as_echo "$as_me: WARNING: libgpm not found. If build fails later consider installing gpm dev package        " >&2;}
+
+
 fi
 
+ ;;
+esac
 
 for ac_header in execinfo.h pty.h util.h zlib.h bzlib.h libutil.h sys/ttydefaults.h
 do :
@@ -8053,15 +8064,6 @@ fi
 
 
 
-case "$host_os" in
-    *)
-	# AC_DEFINE([_XOPEN_SOURCE], [500], [Need pread])
-
-$as_echo "#define _BSD_SOURCE 1" >>confdefs.h
-
-	;;
-esac
-
 ALL_LDFLAGS="$LDFLAGS $SQLITE3_LDFLAGS"
 
 static_lib_list="libncurses.a libreadline.a libsqlite3.a libz.a libtinfo.a"
@@ -8090,16 +8092,16 @@ if test x"${enable_static}" != x"no"; then
     rm -f src/static-libs/*.a
     for libflag in $ALL_LDFLAGS; do
         case $libflag in
-	    -Lstatic-libs)
-		;;
-	    -L*)
+        -Lstatic-libs)
+        ;;
+        -L*)
                 libdir=`echo $libflag | sed -e 's/-L//'`
                 for slib in $static_lib_list; do
                     if test -e "$libdir/$slib"; then
                         ln -sf "$libdir/$slib" src/static-libs/.
                     fi
                 done
-		;;
+        ;;
         esac
     done
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -30,11 +30,11 @@ dnl abssrcdir is the absolute path to the source base (regardless of where
 dnl you are building it)
 case x$srcdir in
 x/*)
-	abssrcdir=$srcdir
-	;;
+    abssrcdir=$srcdir
+    ;;
 *)
-	abssrcdir=`pwd`/$srcdir
-	;;
+    abssrcdir=`pwd`/$srcdir
+    ;;
 esac
 AC_SUBST(abssrcdir)
 
@@ -51,11 +51,11 @@ AC_ARG_ENABLE([profiling],
 
 AC_MSG_CHECKING(gprof(4) profiling support)
 if test x"${enable_profiling}" = x"yes" ; then
-	CFLAGS="$CFLAGS -pg -gstabs"
-	CXXFLAGS="$CXXFLAGS -pg -gstabs"
-	LDFLAGS="$LDFLAGS -pg"
+    CFLAGS="$CFLAGS -pg -gstabs"
+    CXXFLAGS="$CXXFLAGS -pg -gstabs"
+    LDFLAGS="$LDFLAGS -pg"
 else
-	enable_profiling=no
+    enable_profiling=no
 fi
 AC_MSG_RESULT($enable_profiling)
 
@@ -105,7 +105,21 @@ AS_IF([test "x${enable_tinfo}" != "xno"],
     AC_MSG_NOTICE([Building with tinfo linking disabled])
 )
 
-AC_SEARCH_LIBS(Gpm_Open, gpm)
+dnl libgpm is required on some systems where there is a misconfigured ncurses
+dnl and gpm libraries with interdependencies. This check is not required on OS X.
+AS_CASE(["$host_os"],
+    [darwin*],
+    [],
+    AC_SEARCH_LIBS(Gpm_Open, gpm,
+       [],
+       [dnl
+        AC_MSG_WARN(m4_join([ ],
+                    [libgpm not found. If build fails later],
+                    [consider installing gpm dev package])dnl
+        )
+       ]
+    )
+)
 
 AC_CHECK_HEADERS(execinfo.h pty.h util.h zlib.h bzlib.h libutil.h sys/ttydefaults.h)
 
@@ -123,13 +137,6 @@ AX_PATH_LIB_PCRE([], [AC_MSG_ERROR([pcre required to build])])
 AX_PATH_LIB_READLINE
 
 LNAV_WITH_SQLITE3("3.0.0")
-
-case "$host_os" in
-    *)
-	# AC_DEFINE([_XOPEN_SOURCE], [500], [Need pread])
-	AC_DEFINE([_BSD_SOURCE], [1], [Need pread])
-	;;
-esac
 
 ALL_LDFLAGS="$LDFLAGS $SQLITE3_LDFLAGS"
 
@@ -157,16 +164,16 @@ if test x"${enable_static}" != x"no"; then
     rm -f src/static-libs/*.a
     for libflag in $ALL_LDFLAGS; do
         case $libflag in
-	    -Lstatic-libs)
-		;;
-	    -L*)
+        -Lstatic-libs)
+        ;;
+        -L*)
                 libdir=`echo $libflag | sed -e 's/-L//'`
                 for slib in $static_lib_list; do
                     if test -e "$libdir/$slib"; then
                         ln -sf "$libdir/$slib" src/static-libs/.
                     fi
                 done
-		;;
+        ;;
         esac
     done
 fi

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -161,6 +161,3 @@
 
 /* Version number of package */
 #undef VERSION
-
-/* Need pread */
-#undef _BSD_SOURCE


### PR DESCRIPTION
* On some misconfigured systems, libgpm is required along with ncurses.
  I haven't been able to figure out the correct way to figure out these
  dependencies without resorting to using external tools like 'nm'. So
  for the moment, if libgpm is not found, at least warn the user that
  the build might fail later.

* Ncurses on OS X does not require libgpm, so there is no need to test
  for it.

* There seems to be an 'AC_DEFINE' _BSD_SOURCE which does not seem to be
   used anywhere. Removing this for now.

* Remove some artifacts left behind by Emacs.