### PR TITLE
[pretty print] Avoid extra new lines.

### DIFF
--- a/src/pretty_printer.hh
+++ b/src/pretty_printer.hh
@@ -111,7 +111,7 @@ public:
             this->pp_values.push_back(el);
         }
         this->flush_values();
-        this->pp_stream << std::endl << std::ends;
+        this->pp_stream << std::ends;
 
         return this->pp_stream.str();
     };

--- a/test/datafile_xml.0
+++ b/test/datafile_xml.0
@@ -18,4 +18,3 @@ pair  51:61                                                     ^--------^  <clo
     <elem attr1=xyz attr2="123">  </elem>
 
     <closed />
-


### PR DESCRIPTION
With the recent change to enable pretty print on all the log lines in
the current view, 'lnav' adds extra new lines between all the normal log
lines. This change removes the extra new lines.

__Not really sure if this is the correct fix or not but running various logs through lnav after this change seems to work fine.__