### PR TITLE
[travis] Print out the logs after failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
     - tar -xvf /tmp/automake.tar.gz
     - (cd automake-1.15 && ./configure && make && sudo make install)
 script: ./autogen.sh && ./configure && make && make check
-after_script: [ -e test/test-suite.log ] && cat test/test-suite.log
+after_script: test -e test/test-suite.log && cat test/test-suite.log
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ before_install:
     - wget http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz -O /tmp/automake.tar.gz
     - tar -xvf /tmp/automake.tar.gz
     - (cd automake-1.15 && ./configure && make && sudo make install)
-script: ./autogen.sh && ./configure && make && make check && cat test/test-suite.log
+script: ./autogen.sh && ./configure && make && make check
+after_script: [ -e test/test-suite.log ] && cat test/test-suite.log
 
 env:
   global:


### PR DESCRIPTION
I think if `make check` fails, the `&&` will short out and will not print the logs
when it is most useful. Print out the log as an 'after_script'.

__Going on a hunch here. Will see what travis does during pull request.__