### PR TITLE
[build] Get rid of warnings from autoreconf.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 
-AC_INIT(lnav, 0.7.2, lnav@googlegroups.com, lnav, [http://lnav.org])
+AC_INIT([lnav],[0.7.2],[lnav@googlegroups.com],[lnav],[http://lnav.org])
 AC_CONFIG_SRCDIR([src/lnav.cc])
-AC_CONFIG_MACRO_DIRS([m4])
+AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_SILENT_RULES([yes])
 

--- a/m4/ax_with_curses.m4
+++ b/m4/ax_with_curses.m4
@@ -184,7 +184,6 @@
 
 #serial 13
 
-AU_ALIAS([MP_WITH_CURSES], [AX_WITH_CURSES])
 AC_DEFUN([AX_WITH_CURSES], [
     AC_ARG_VAR([CURSES_LIB], [linker library for Curses, e.g. -lcurses])
     AC_ARG_WITH([ncurses], [AS_HELP_STRING([--with-ncurses],

--- a/m4/lnav_with_jemalloc.m4
+++ b/m4/lnav_with_jemalloc.m4
@@ -20,7 +20,8 @@ dnl
 dnl
 AC_DEFUN([LNAV_WITH_JEMALLOC], [
 enable_jemalloc=no
-AC_ARG_WITH([jemalloc], [AC_HELP_STRING([--with-jemalloc=DIR], [use a specific jemalloc library])],
+AC_ARG_WITH([jemalloc],
+    [AS_HELP_STRING([--with-jemalloc=DIR],[use a specific jemalloc library])],
 [
     if test "$withval" != "no"; then
         enable_jemalloc=yes

--- a/m4/lnav_with_readline.m4
+++ b/m4/lnav_with_readline.m4
@@ -34,10 +34,8 @@ AC_DEFUN([AX_PATH_LIB_READLINE],
     AC_REQUIRE([AX_WITH_CURSES])
     AC_MSG_CHECKING([lib readline])
     AC_ARG_WITH([readline],
-        AC_HELP_STRING(
-            [--with-readline@<:@=prefix@:>@],
-            [compile xmlreadline part (via libreadline check)]
-        ),
+        AS_HELP_STRING([--with-readline@<:@=prefix@:>@],dnl
+            [compile xmlreadline part (via libreadline check)]),
         [],
         [with_readline="yes"]
     )dnl

--- a/m4/lnav_with_sqlite3.m4
+++ b/m4/lnav_with_sqlite3.m4
@@ -11,10 +11,7 @@ dnl
 AC_DEFUN([LNAV_WITH_SQLITE3],
 [dnl
     AC_ARG_WITH([sqlite3],
-        AC_HELP_STRING(
-            [--with-sqlite3=@<:@prefix@:>@],
-            [compile with sqlite3]
-        ),
+        AS_HELP_STRING([--with-sqlite3=@<:@prefix@:>@],[compile with sqlite3]),
         [],
         [with_sqlite3="yes"]
     )

--- a/m4/lnav_with_yajl.m4
+++ b/m4/lnav_with_yajl.m4
@@ -30,10 +30,7 @@ dnl @file lnav_with_yajl.m4
 AC_DEFUN([LNAV_WITH_LOCAL_YAJL],
     [
     AC_ARG_WITH([yajl],
-        AC_HELP_STRING(
-            [--with-yajl=DIR],
-            [use a local installed version of yajl]
-        ),
+        AS_HELP_STRING([--with-yajl=DIR],[use a local installed version of yajl]),
         [
         AS_IF([test "$withval" != "no"],
             [


### PR DESCRIPTION
* Remove some of the obsolete macros.
* Use AC_CONFIG_MACRO_DIR to allow compatibility with older versions of
  autoconf.
* Remove AU_ALIAS from curses macro.