### PR TITLE
[-Wformat] Fix scripty.cc again.

### DIFF
--- a/test/scripty.cc
+++ b/test/scripty.cc
@@ -623,7 +623,7 @@ int main(int argc, char *argv[])
 				fprintf(scripty_data.sd_to_child,
 					"sleep %ld.%06ld\n"
 					"write ",
-					diff.tv_sec, diff.tv_usec);
+					(long)diff.tv_sec, (long)diff.tv_usec);
 				dump_memory(scripty_data.sd_to_child,
 					    buffer,
 					    rc);


### PR DESCRIPTION
Seems like timeval is defined differently on OS X than on Linux. So
fixing the format specifier on one breaks it on the other. Explicitly
cast the value being passed in to fix the problem on both the platforms.