### PR TITLE
[build] Turn 'sign-compare' in to an error.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -64,6 +64,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-DSYSCONFDIR='"$(sysconfdir)"' \
 	-Wall \
+	-Werror=sign-compare \
 	$(READLINE_CFLAGS) \
 	$(SQLITE3_CFLAGS)
 


### PR DESCRIPTION
Can't turn on the same on tests because it breaks on some test cases.