### PR TITLE
[terminal] Print out an error when openpty fails.

### DIFF
--- a/src/readline_curses.cc
+++ b/src/readline_curses.cc
@@ -309,6 +309,7 @@ readline_curses::readline_curses()
                 NULL,
                 NULL,
                 &ws) < 0) {
+        perror("error: failed to open terminal(openpty)");
         throw error(errno);
     }
 


### PR DESCRIPTION
tstack/lnav#206