### PR TITLE
[pretty] Don't wait indefinitely for reverse IP lookups.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -141,6 +141,7 @@ noinst_HEADERS = \
 	textfile_sub_source.hh \
 	textview_curses.hh \
 	time_T.hh \
+	timer.hh \
 	top_status_source.hh \
 	view_curses.hh \
 	vt52_curses.hh \
@@ -203,6 +204,7 @@ libdiag_a_SOURCES = \
 	sqlite-extension-func.c \
 	statusview_curses.cc \
 	string-extension-functions.cc \
+	timer.cc \
 	pcrepp.cc \
 	piper_proc.cc \
 	sql_util.cc \

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -47,7 +47,7 @@ int timer::interrupt_timer::arm_timer() {
     return 0;
 }
 
-timer::interrupt_timer::~interrupt_timer() {
+void timer::interrupt_timer::disarm_timer() {
     if (this->armed) {
         // Disable the interval timer before resetting the handler and rearming
         // the previous interval timer or else we will have a race-condition
@@ -69,4 +69,8 @@ timer::interrupt_timer::~interrupt_timer() {
             throw timer::error(errno);
         }
     }
+}
+
+timer::interrupt_timer::~interrupt_timer() {
+    this->disarm_timer();
 }

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -1,0 +1,79 @@
+#include "timer.hh"
+#include "lnav_log.hh"
+
+const struct itimerval disable = {
+    { 0, 0 },
+    { 0, 0 }
+};
+
+timer::error::error(int err):e_err(err) { }
+
+timer::interrupt_timer::interrupt_timer(struct timeval t,
+        sighandler_t_ sighandler=SIG_IGN) : new_handler(sighandler),
+        old_handler(NULL), armed(true) {
+    this->new_val = (struct itimerval){
+        { 0, 0 },
+        t
+    };
+    this->old_val = (struct itimerval){
+        { 0, 0 },
+        { 0, 0 }
+    };
+}
+
+int timer::interrupt_timer::arm_timer() {
+    // Disable the interval timer before resetting the handler and rearming
+    // the previous interval timer or else we will have a race-condition
+    // where the timer might fire and the appropriate handler might not be
+    // set.
+    if (setitimer(ITIMER_REAL, &disable, &this->old_val) != 0) {
+        log_error("Unable to disable the timer: %s",
+                  strerror(errno));
+        return -1;
+    }
+    this->old_handler = signal(SIGALRM, this->new_handler);
+    if (this->old_handler == SIG_ERR) {
+        log_error("Unable to set the signal handler: %s",
+                  strerror(errno));
+        if (setitimer(ITIMER_REAL, &this->old_val, NULL) != 0) {
+            log_error("Unable to reset the interrupt timer: %s", strerror(errno));
+            throw timer::error(errno);
+        }
+        return -1;
+    }
+
+    if (setitimer(ITIMER_REAL, &this->new_val, NULL) != 0) {
+        if(signal(SIGALRM, this->old_handler) == SIG_ERR) {
+            log_error("Unable to reset the signal handler: %s", strerror(errno));
+            throw timer::error(errno);
+        }
+        log_error("Unable to set the timer: %s", strerror(errno));
+        return -1;
+    }
+    this->armed = true;
+    return 0;
+}
+
+timer::interrupt_timer::~interrupt_timer() {
+    if (this->armed) {
+        // Disable the interval timer before resetting the handler and rearming
+        // the previous interval timer or else we will have a race-condition
+        // where the timer might fire and the appropriate handler might not be
+        // set.
+        if (setitimer(ITIMER_REAL, &disable, NULL) != 0) {
+            log_error("Failed to disable the timer: %s",
+                      strerror(errno));
+            throw timer::error(errno);
+        }
+        if (signal(SIGALRM, this->old_handler) == SIG_ERR) {
+            log_error("Failed to reinstall previous SIGALRM handler: %s",
+                      strerror(errno));
+            throw timer::error(errno);
+        }
+        if (setitimer(ITIMER_REAL, &this->old_val, NULL) != 0) {
+            log_error("Failed to reset the timer to previous value: %s",
+                      strerror(errno));
+            throw timer::error(errno);
+        }
+    }
+}

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -10,22 +10,13 @@ timer::error::error(int err):e_err(err) { }
 
 timer::interrupt_timer::interrupt_timer(struct timeval t,
         sighandler_t_ sighandler=SIG_IGN) : new_handler(sighandler),
-        old_handler(NULL), armed(true) {
-    this->new_val = (struct itimerval){
-        { 0, 0 },
-        t
-    };
-    this->old_val = (struct itimerval){
-        { 0, 0 },
-        { 0, 0 }
-    };
-}
+        old_handler(NULL), new_val((struct itimerval){{0,0},t}),
+        old_val(disable), armed(true) { }
 
 int timer::interrupt_timer::arm_timer() {
-    // Disable the interval timer before resetting the handler and rearming
-    // the previous interval timer or else we will have a race-condition
-    // where the timer might fire and the appropriate handler might not be
-    // set.
+    // Disable the interval timer before setting the handler and arming the
+    // interval timer or else we will have a race-condition where the timer
+    // might fire and the appropriate handler might not be set.
     if (setitimer(ITIMER_REAL, &disable, &this->old_val) != 0) {
         log_error("Unable to disable the timer: %s",
                   strerror(errno));
@@ -36,7 +27,8 @@ int timer::interrupt_timer::arm_timer() {
         log_error("Unable to set the signal handler: %s",
                   strerror(errno));
         if (setitimer(ITIMER_REAL, &this->old_val, NULL) != 0) {
-            log_error("Unable to reset the interrupt timer: %s", strerror(errno));
+            log_error("Unable to reset the interrupt timer: %s",
+                      strerror(errno));
             throw timer::error(errno);
         }
         return -1;
@@ -44,7 +36,8 @@ int timer::interrupt_timer::arm_timer() {
 
     if (setitimer(ITIMER_REAL, &this->new_val, NULL) != 0) {
         if(signal(SIGALRM, this->old_handler) == SIG_ERR) {
-            log_error("Unable to reset the signal handler: %s", strerror(errno));
+            log_error("Unable to reset the signal handler: %s",
+                      strerror(errno));
             throw timer::error(errno);
         }
         log_error("Unable to set the timer: %s", strerror(errno));

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -1,3 +1,32 @@
+/**
+ * Copyright (c) 2015, Suresh Sundriyal
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * * Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include "timer.hh"
 #include "lnav_log.hh"
 
@@ -11,7 +40,7 @@ timer::error::error(int err):e_err(err) { }
 timer::interrupt_timer::interrupt_timer(struct timeval t,
         sighandler_t_ sighandler=SIG_IGN) : new_handler(sighandler),
         old_handler(NULL), new_val((struct itimerval){{0,0},t}),
-        old_val(disable), armed(true) { }
+        old_val(disable), armed(false) { }
 
 int timer::interrupt_timer::arm_timer() {
     // Disable the interval timer before setting the handler and arming the
@@ -47,6 +76,10 @@ int timer::interrupt_timer::arm_timer() {
     return 0;
 }
 
+bool timer::interrupt_timer::is_armed() {
+    return this->armed;
+}
+
 void timer::interrupt_timer::disarm_timer() {
     if (this->armed) {
         // Disable the interval timer before resetting the handler and rearming
@@ -68,6 +101,9 @@ void timer::interrupt_timer::disarm_timer() {
                       strerror(errno));
             throw timer::error(errno);
         }
+        this->armed = false;
+        this->old_val = disable;
+        this->old_handler = NULL;
     }
 }
 

--- a/src/timer.hh
+++ b/src/timer.hh
@@ -1,0 +1,33 @@
+#ifndef timer_hh
+#define timer_hh
+
+#include <errno.h>
+#include <signal.h>
+#include <exception>
+#include <sys/time.h>
+#include <sys/types.h>
+
+// Linux and BSD seem to name the function pointer to signal handler differently.
+// Linux names it 'sighandler_t' and BSD names it 'sig_t'. Instead of depending
+// on configure scripts to find out the type name, typedef it right here.
+typedef void (*sighandler_t_)(int);
+
+namespace timer{
+class error : public std::exception {
+    public:
+        error(int err);
+        int e_err;
+};
+
+class interrupt_timer {
+    public:
+        interrupt_timer(struct timeval, sighandler_t_);
+        int arm_timer();
+        ~interrupt_timer();
+    private:
+        struct itimerval new_val, old_val;
+        sighandler_t_ new_handler, old_handler;
+        bool armed;
+};
+}
+#endif

--- a/src/timer.hh
+++ b/src/timer.hh
@@ -25,8 +25,8 @@ class interrupt_timer {
         int arm_timer();
         ~interrupt_timer();
     private:
-        struct itimerval new_val, old_val;
         sighandler_t_ new_handler, old_handler;
+        struct itimerval new_val, old_val;
         bool armed;
 };
 }

--- a/src/timer.hh
+++ b/src/timer.hh
@@ -1,3 +1,32 @@
+/**
+ * Copyright (c) 2015, Suresh Sundriyal
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * * Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #ifndef timer_hh
 #define timer_hh
 
@@ -24,6 +53,7 @@ class interrupt_timer {
         interrupt_timer(struct timeval, sighandler_t_);
         int arm_timer();
         void disarm_timer();
+        bool is_armed();
         ~interrupt_timer();
     private:
         sighandler_t_ new_handler, old_handler;

--- a/src/timer.hh
+++ b/src/timer.hh
@@ -23,6 +23,7 @@ class interrupt_timer {
     public:
         interrupt_timer(struct timeval, sighandler_t_);
         int arm_timer();
+        void disarm_timer();
         ~interrupt_timer();
     private:
         sighandler_t_ new_handler, old_handler;


### PR DESCRIPTION
Reverse lookup for pretty print should be a best effort undertaking. So,
+ Give up on EAI_AGAIN.
+ Don't block on the getnameinfo call indefinitely, resolv.conf might be
  set up with a large timeout.
+ Disable lookups after the first failure.