### PR TITLE
[build] Require sqlite3 to be at least version 3.3.9.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,7 +128,7 @@ fi
 AX_PATH_LIB_PCRE([], [AC_MSG_ERROR([pcre required to build])])
 AX_PATH_LIB_READLINE
 
-LNAV_WITH_SQLITE3("3.0.0")
+LNAV_WITH_SQLITE3("3.3.9")
 
 case "$host_os" in
     *)


### PR DESCRIPTION
'sqlite3_prepare_v2' was first introduced in version 3.3.9, which is
about 8 years old by now.