### PR TITLE
Require sqlite3-v3.6.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,7 +128,7 @@ fi
 AX_PATH_LIB_PCRE([], [AC_MSG_ERROR([pcre required to build])])
 AX_PATH_LIB_READLINE
 
-LNAV_WITH_SQLITE3("3.3.9")
+LNAV_WITH_SQLITE3("3.6.0")
 
 case "$host_os" in
     *)


### PR DESCRIPTION
v3.6.0 was the last released version of sqlite3 that I could
successfully compile with without any source changes. I could
compile with v3.4.2 but that required some code changes and lnav
crashed regularly after that.