### PR TITLE
[generic_log] Incorrect string length being passed in.

### DIFF
--- a/src/log_format_impls.cc
+++ b/src/log_format_impls.cc
@@ -146,7 +146,7 @@ class generic_log_format : public log_format {
                 &level)) != NULL) {
             const char *level_str = &sbr.get_data()[level.c_begin];
             logline::level_t level_val = logline::string2level(
-                    level_str, level.length());
+                    level_str, strlen(level_str));
 
             this->check_for_new_year(dst, log_tv);
 

--- a/test/logfile_generic.1
+++ b/test/logfile_generic.1
@@ -1,2 +1,4 @@
 2015-04-24T21:09:29.296 25376]INFO:somemodule:Something very INFOrmative.
 2015-04-24T21:09:39.296 25376]ERROR:somemodule:Something very INFOrmative.
+2015-05-02T18:26:53.273+00:0000 Nothing very INFOrmative.
+2015-05-02T18:26:53.273+00:0000 Some aweful ErrOr.

--- a/test/test_logfile.sh
+++ b/test/test_logfile.sh
@@ -182,6 +182,8 @@ run_test ./drive_logfile -v -f generic_log ${srcdir}/logfile_generic.1
 check_output "generic_log level interpreted incorrectly?" <<EOF
 0x07
 0x0a
+0x07
+0x0a
 EOF
 
 touch -t 200711030923 ${srcdir}/logfile_glog.0


### PR DESCRIPTION
It still seems like generic_log expects the log level to be the first
thing in the log line after the timestamp. Looking at the scan function
in log_format_impl.cc, it seems like an incorrect length is being passed
in to string2format function.