### PR TITLE
Adding smaller movements to left and right via shift-arrows or H and L.

### DIFF
--- a/src/listview_curses.cc
+++ b/src/listview_curses.cc
@@ -102,7 +102,7 @@ bool listview_curses::handle_key(int ch)
     case 'H':
     case KEY_SLEFT:
         this->shift_left(-10);
-        break
+        break;
 
     case '\r':
     case 'j':

--- a/src/listview_curses.cc
+++ b/src/listview_curses.cc
@@ -95,6 +95,14 @@ bool listview_curses::handle_key(int ch)
     case KEY_LEFT:
         this->shift_left(-(width / 2));
         break;
+    case 'L':
+    case KEY_SRIGHT:
+        this->shift_left(10);
+        break;
+    case 'H':
+    case KEY_SLEFT:
+        this->shift_left(-10);
+        break
 
     case '\r':
     case 'j':


### PR DESCRIPTION
Hi there!

I found myself wanting a smaller horizontal movement than the half screen width currently implemented.  So I added shift-left and shift right along with H and L to shift the window by ten characters.

I think I've got the directions correct - right shifts the screen left and left shifts the screen right, similar to how left and right and h and l work.

Hope this helps,

Paul