### PR TITLE
[log_format] Don't capture the sub-groups.

### DIFF
--- a/src/log_format.cc
+++ b/src/log_format.cc
@@ -82,7 +82,7 @@ const char *logline::level_names[LEVEL__MAX + 1] = {
 };
 
 static pcrepp LEVEL_RE(
-        "(?i)(TRACE|DEBUG\\d*|INFO|STATS|WARN(?:ING)?|ERR(OR)?|CRITICAL|SEVERE|FATAL)");
+        "(?i)(TRACE|DEBUG\\d*|INFO|STATS|WARN(?:ING)?|ERR(?:OR)?|CRITICAL|SEVERE|FATAL)");
 
 logline::level_t logline::string2level(const char *levelstr, ssize_t len, bool exact)
 {


### PR DESCRIPTION
I don't think there is any reason to capture the (OR) sub-group in
ERR(OR) separately.