### PR TITLE
[syslog_log] Case-insensitive search for level strings

### DIFF
--- a/src/default-log-formats.json
+++ b/src/default-log-formats.json
@@ -586,8 +586,8 @@
         },
         "level-field" : "body",
         "level" : {
-            "error" : "(?:failed|failure|error)",
-            "warning" : "(?:warn|not responding|init: cannot execute)"
+            "error" : "(?:(?:(?<![a-zA-Z]))(?:(?i)error(?:s)?)(?:(?![a-zA-Z]))|failed|failure)",
+            "warning" : "(?:(?:(?i)warn)|not responding|init: cannot execute)"
         },
         "value" : {
             "log_hostname" : {


### PR DESCRIPTION
While looking through syslog messages on OS X, came across plenty of
error/warning messages where the level was in all-caps and as a result
were not recognized. There was also a lot of false positives due to the
word error turning up as part of a longer string.

This change:
- Changes the log level regex to do a case-insensitive search.
- Ognores the string 'error', if it is part of a longer string.