### PR TITLE
[coverity] Avoid a buffer-overrun.

### DIFF
--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -3863,7 +3863,10 @@ static void looper(void)
                     while ((ch = getch()) != ERR) {
                         alerter::singleton().new_input(ch);
 
-                        if (escape_index >= sizeof(escape_buffer) - 1) {
+                        /* Check to make sure there is enough space for a
+                         * character and a string terminator.
+                         */
+                        if (escape_index >= sizeof(escape_buffer) - 2) {
                             escape_index = 0;
                         }
                         else if (escape_index > 0) {


### PR DESCRIPTION
'escape_index' is ensured to be less than 'sizeof(escape_buffer)-1'.
This guarantees enough space for one more character in the
escape_buffer. However, if we meet this condition, we go ahead and shove
a character and a null-terminator in to the string, potentially leading
to a buffer overrun.