### PR TITLE
[cURL] Allow libcurl to be dynamically linked in on OS X.

### DIFF
--- a/m4/libcurl.m4
+++ b/m4/libcurl.m4
@@ -143,6 +143,23 @@ AC_DEFUN([LIBCURL_CHECK_CONFIG],
               esac
            fi
 
+           dnl If we are on OS X and we haven't picked up libcurl static or
+           dnl otherwise, then let's just go ahead and use the one present on
+           dnl the system. Since this compiled binary will only run on OS X
+           dnl which almost always has cURL installed, it's OK to add the
+           dnl static dependency.
+           AS_IF([test "x${LIBCURL}" = "x"],
+                [AS_CASE(["$host_os"],
+                    [darwin*],
+                    [AS_IF([test "x$_libcurl_config" != "x"],
+                        AS_VAR_SET(LIBCURL, $($_libcurl_config --libs)),
+                        []
+                    )],
+                    []
+                )],
+                []
+            )
+
            # All curl-config scripts support --feature
            _libcurl_features=`$_libcurl_config --feature`
 


### PR DESCRIPTION
This fixes tstack/lnav#253

The libcurl.m4 macros will still continue to look for a static archive
for libcurl but if one is not found and the binary is being compiled on
OS X, they will pick up the dynamic library if one is available.