### PR TITLE
Added O_TRUNC flag so new format installation doesn't result in …

### DIFF
--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -2392,7 +2392,7 @@ int main(int argc, char *argv[])
                 perror("unable to open file to install");
             }
             else if ((out_fd = open(dst_path.c_str(),
-                    O_WRONLY | O_CREAT, 0644)) == -1) {
+                    O_WRONLY | O_CREAT | O_TRUNC, 0644)) == -1) {
                 fprintf(stderr, "error: unable to open destination: %s -- %s\n",
                         dst_path.c_str(), strerror(errno));
             }


### PR DESCRIPTION
trailing garbage message. This would happen if the file to be installed was shorter than the one already there. 