### PR TITLE
[commands] Read and honor the 'LNAVSECURE' environment variable.

### DIFF
--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -2230,6 +2230,16 @@ int main(int argc, char *argv[])
     setlocale(LC_NUMERIC, "");
     umask(077);
 
+    /* Disable Lnav from being able to execute external commands if
+     * "LNAVSECURE" environment variable is set by the user.
+     */
+    if (getenv("LNAVSECURE") != NULL) {
+        lnav_data.ld_secure_mode = true;
+    }
+    else {
+        lnav_data.ld_secure_mode = false;
+    }
+
     lnav_data.ld_program_name = argv[0];
     lnav_data.ld_local_vars.push(map<string, string>());
     add_ansi_vars(lnav_data.ld_local_vars.top());

--- a/src/lnav.hh
+++ b/src/lnav.hh
@@ -251,6 +251,7 @@ struct _lnav_data {
 
     std::list<pid_t>                        ld_children;
     std::list<piper_proc *>                 ld_pipers;
+    bool                                    ld_secure_mode;
     xterm_mouse ld_mouse;
     term_extra ld_term_extra;
 

--- a/src/lnav_commands.cc
+++ b/src/lnav_commands.cc
@@ -454,6 +454,10 @@ static string com_save_to(string cmdline, vector<string> &args)
         return "";
     }
 
+    if (lnav_data.ld_secure_mode) {
+        return args[0] + ": unavailable in secure mode";
+    }
+
     if (args.size() < 2) {
         return "error: expecting file name or '-' to write to the terminal";
     }
@@ -646,6 +650,10 @@ static string com_pipe_to(string cmdline, vector<string> &args)
     if (args.size() == 0) {
         args.push_back("filename");
         return "";
+    }
+
+    if (lnav_data.ld_secure_mode) {
+        return args[0] + ": unavailable in secure mode";
     }
 
     if (args.size() < 2) {
@@ -1341,6 +1349,9 @@ static string com_open(string cmdline, vector<string> &args)
     if (args.size() == 0) {
         args.push_back("filename");
         return "";
+    }
+    else if (lnav_data.ld_secure_mode) {
+        return args[0] + ": unavailable in secure mode";
     }
     else if (args.size() < 2) {
         return retval;

--- a/test/test_cmds.sh
+++ b/test/test_cmds.sh
@@ -395,6 +395,8 @@ run_test ${lnav_test} -n \
     -c ':write-json-to -' \
     ${test_dir}/logfile_access_log.0
 
+
+
 check_output "write-json-to is not working" <<EOF
 [
     {
@@ -454,6 +456,23 @@ check_output "write-json-to is not working" <<EOF
 ]
 EOF
 
+
+# By setting the LNAVSECURE mode before executing the command, we will disable
+# the access to the write-json-to command and the output would just be the
+# actual display of select query rather than json output.
+export LNAVSECURE=1
+run_test ${lnav_test} -n \
+    -c ";select * from access_log" \
+    -c ':write-json-to -' \
+    ${test_dir}/logfile_access_log.0
+
+check_output "We managed to bypass LNAVSECURE mode" <<EOF
+log_line log_part         log_time        log_idle_msecs log_level log_mark       c_ip      cs_method cs_referer cs_uri_query            cs_uri_stem           cs_user_agent cs_username cs_version sc_bytes sc_status
+       0   <NULL> 2009-07-20 22:59:26.000              0 info             0 192.168.202.254 GET       -                <NULL> /vmw/cgi/tramp                   gPXE/0.9.7    -           HTTP/1.0        134       200
+       1   <NULL> 2009-07-20 22:59:29.000           3000 error            0 192.168.202.254 GET       -                <NULL> /vmw/vSphere/default/vmkboot.gz  gPXE/0.9.7    -           HTTP/1.0      46210       404
+       2   <NULL> 2009-07-20 22:59:29.000              0 info             0 192.168.202.254 GET       -                <NULL> /vmw/vSphere/default/vmkernel.gz gPXE/0.9.7    -           HTTP/1.0      78929       200
+EOF
+unset LNAVSECURE
 
 run_test ${lnav_test} -n \
     -c ";update generic_log set log_mark=1" \


### PR DESCRIPTION
Read the value of the 'LNAVSECURE' environment variable upfront and
store it in the lnav_data structure. When this variable is set prior to
the binary execution, the following commands are disabled:

* 'open'
* 'pipe-to'
* 'pipe-line-to'
* 'write-*-to'

This is a proposed fix for tstack/lnav#305.