### PR TITLE
[commands] Read and honor the 'LNAVSECURE' environment variable.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -46,7 +46,6 @@ lnav v0.8.1:
        - pipe-to
        - pipe-line-to
        - write-*-to
-       - eval
        This makes it easier to run lnav with escalated privileges in restricted
        environments, without the risk of users being able to use the above
        mentioned commands to gain privileged access.

--- a/NEWS
+++ b/NEWS
@@ -40,6 +40,16 @@ lnav v0.8.1:
      * Added a "/ui/clock-format" configuration option that controls the time
        format in the top-left corner.
      * Added support for TAI64 timestamps (http://cr.yp.to/libtai/tai64.html).
+     * Added a safe execution mode. If 'LNAVSECURE' environment variable is set
+       before executing lnav, the following commands are disabled:
+       - open
+       - pipe-to
+       - pipe-line-to
+       - write-*-to
+       - eval
+       This makes it easier to run lnav with escalated privileges in restricted
+       environments, without the risk of users being able to use the above
+       mentioned commands to gain privileged access.
 
      Interface Changes:
      * The 'o/O' hotkeys have been reassigned to navigate through log

--- a/NEWS
+++ b/NEWS
@@ -40,8 +40,8 @@ lnav v0.8.1:
      * Added a "/ui/clock-format" configuration option that controls the time
        format in the top-left corner.
      * Added support for TAI64 timestamps (http://cr.yp.to/libtai/tai64.html).
-     * Added a safe execution mode. If 'LNAVSECURE' environment variable is set
-       before executing lnav, the following commands are disabled:
+     * Added a safe execution mode. If the 'LNAVSECURE' environment variable is
+       set before executing lnav, the following commands are disabled:
        - open
        - pipe-to
        - pipe-line-to

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -143,7 +143,6 @@ The following options are available:
    environment variable before executing the **lnav** binary:
 
    - open
-   - eval
    - pipe-to
    - pipe-line-to
    - write-*-to

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -138,3 +138,15 @@ The following options are available:
 * /ui/clock-format - Specifies the date-time format of the clock in the
   top-left corner of the UI.  The format conversion specifiers are the same as
   in strftime(3).
+
+.. note:: The following commands can be disabled by setting the ``LNAVSECURE``
+   environment variable before executing the **lnav** binary:
+
+   - open
+   - eval
+   - pipe-to
+   - pipe-line-to
+   - write-*-to
+
+   This makes it easier to run lnav in restricted environments without the risk
+   of privilege escalation.

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -2230,6 +2230,13 @@ int main(int argc, char *argv[])
     setlocale(LC_NUMERIC, "");
     umask(077);
 
+    /* Disable Lnav from being able to execute external commands if
+     * "LNAVSECURE" environment variable is set by the user.
+     */
+    if (getenv("LNAVSECURE") != NULL) {
+        lnav_data.ld_flags |= LNF_SECURE_MODE;
+    }
+
     lnav_data.ld_program_name = argv[0];
     lnav_data.ld_local_vars.push(map<string, string>());
     add_ansi_vars(lnav_data.ld_local_vars.top());

--- a/src/lnav.hh
+++ b/src/lnav.hh
@@ -88,6 +88,7 @@ enum {
     LNB_INSTALL,
     LNB_UPDATE_FORMATS,
     LNB_VERBOSE,
+    LNB_SECURE_MODE,
 };
 
 /** Flags set on the lnav command-line. */
@@ -104,8 +105,9 @@ typedef enum {
     LNF_INSTALL   = (1L << LNB_INSTALL),
     LNF_UPDATE_FORMATS = (1L << LNB_UPDATE_FORMATS),
     LNF_VERBOSE = (1L << LNB_VERBOSE),
+    LNF_SECURE_MODE = (1L << LNB_SECURE_MODE),
 
-    LNF__ALL      = (LNF_SYSLOG|LNF_HELP)
+    LNF__ALL      = (LNF_SYSLOG|LNF_HELP),
 } lnav_flags_t;
 
 /** The different views available. */

--- a/src/lnav_commands.cc
+++ b/src/lnav_commands.cc
@@ -454,6 +454,10 @@ static string com_save_to(string cmdline, vector<string> &args)
         return "";
     }
 
+    if (lnav_data.ld_flags & LNF_SECURE_MODE) {
+        return "error: " + args[0] + " -- unavailable in secure mode";
+    }
+
     if (args.size() < 2) {
         return "error: expecting file name or '-' to write to the terminal";
     }
@@ -646,6 +650,10 @@ static string com_pipe_to(string cmdline, vector<string> &args)
     if (args.size() == 0) {
         args.push_back("filename");
         return "";
+    }
+
+    if (lnav_data.ld_flags & LNF_SECURE_MODE) {
+        return "error: " + args[0] + " -- unavailable in secure mode";
     }
 
     if (args.size() < 2) {
@@ -1341,6 +1349,9 @@ static string com_open(string cmdline, vector<string> &args)
     if (args.size() == 0) {
         args.push_back("filename");
         return "";
+    }
+    else if (lnav_data.ld_flags & LNF_SECURE_MODE) {
+        return "error: " + args[0] + " -- unavailable in secure mode";
     }
     else if (args.size() < 2) {
         return retval;
@@ -2230,6 +2241,9 @@ static string com_eval(string cmdline, vector<string> &args)
 
     if (args.empty()) {
 
+    }
+    else if (lnav_data.ld_flags & LNF_SECURE_MODE) {
+        return "error: " + args[0] + " -- unavailable in secure mode";
     }
     else if (args.size() > 1) {
         string all_args = remaining_args(cmdline, args);

--- a/src/lnav_commands.cc
+++ b/src/lnav_commands.cc
@@ -2242,9 +2242,6 @@ static string com_eval(string cmdline, vector<string> &args)
     if (args.empty()) {
 
     }
-    else if (lnav_data.ld_flags & LNF_SECURE_MODE) {
-        return "error: " + args[0] + " -- unavailable in secure mode";
-    }
     else if (args.size() > 1) {
         string all_args = remaining_args(cmdline, args);
         string expanded_cmd;

--- a/test/test_cmds.sh
+++ b/test/test_cmds.sh
@@ -395,6 +395,8 @@ run_test ${lnav_test} -n \
     -c ':write-json-to -' \
     ${test_dir}/logfile_access_log.0
 
+
+
 check_output "write-json-to is not working" <<EOF
 [
     {
@@ -454,6 +456,20 @@ check_output "write-json-to is not working" <<EOF
 ]
 EOF
 
+
+# By setting the LNAVSECURE mode before executing the command, we will disable
+# the access to the write-json-to command and the output would just be the
+# actual display of select query rather than json output.
+export LNAVSECURE=1
+run_test ${lnav_test} -n \
+    -c ";select * from access_log" \
+    -c ':write-json-to -' \
+    ${test_dir}/logfile_access_log.0
+
+check_error_output "We managed to bypass LNAVSECURE mode" <<EOF
+error: write-json-to -- unavailable in secure mode
+EOF
+unset LNAVSECURE
 
 run_test ${lnav_test} -n \
     -c ";update generic_log set log_mark=1" \


### PR DESCRIPTION
Read the value of the 'LNAVSECURE' environment variable upfront and
store it in the lnav_data structure. When this variable is set prior to
the binary execution, the following commands are disabled:

* 'open'
* 'pipe-to'
* 'pipe-line-to'
* 'write-*-to'

This is a proposed fix for tstack/lnav#305.