### PR TITLE
[secure-mode] Prevent users from attaching db files.

### DIFF
--- a/m4/lnav_with_sqlite3.m4
+++ b/m4/lnav_with_sqlite3.m4
@@ -95,6 +95,12 @@ AC_DEFUN([LNAV_WITH_SQLITE3],
         )
     )
 
+    AC_CHECK_FUNC(sqlite3_compileoption_used,
+        AC_DEFINE([HAVE_SQLITE3_COMPILEOPTION_USED], [],
+            [Have sqlite3_compileoption_used function]
+        )
+    )
+
     AC_SUBST(HAVE_SQLITE3_VALUE_SUBTYPE)
 
     AS_VAR_SET(CFLAGS, $saved_CFLAGS)

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -2476,6 +2476,13 @@ int main(int argc, char *argv[])
         fprintf(stderr, "error: unable to create sqlite memory database\n");
         exit(EXIT_FAILURE);
     }
+    else if (lnav_data.ld_flags & LNF_SECURE_MODE) {
+        if ((sqlite3_set_authorizer(lnav_data.ld_db.in(),
+                                    sqlite_authorizer, NULL)) != SQLITE_OK) {
+            fprintf(stderr, "error: unable to attach sqlite authorizer\n");
+            exit(EXIT_FAILURE);
+        }
+    }
 
     /* If we statically linked against an ncurses library that had a non-
      * standard path to the terminfo database, we need to set this variable

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -2476,7 +2476,8 @@ int main(int argc, char *argv[])
         fprintf(stderr, "error: unable to create sqlite memory database\n");
         exit(EXIT_FAILURE);
     }
-    else if (lnav_data.ld_flags & LNF_SECURE_MODE) {
+
+    if (lnav_data.ld_flags & LNF_SECURE_MODE) {
         if ((sqlite3_set_authorizer(lnav_data.ld_db.in(),
                                     sqlite_authorizer, NULL)) != SQLITE_OK) {
             fprintf(stderr, "error: unable to attach sqlite authorizer\n");

--- a/src/sql_util.cc
+++ b/src/sql_util.cc
@@ -713,3 +713,30 @@ void sqlite_close_wrapper(void *mem)
 {
     sqlite3_close((sqlite3 *)mem);
 }
+
+int sqlite_authorizer(void *pUserData, int action_code, const char *detail1,
+                      const char *detail2, const char *detail3,
+                      const char *detail4)
+{
+    if (action_code == SQLITE_ATTACH)
+    {
+        /* Check to see that the filename is not NULL */
+        if (detail1 != NULL) {
+            string fileName(detail1);
+
+            /* A temporary database is fine. */
+            if (fileName.length()) {
+                 /* In-memory databases are fine.
+                 */
+                if (fileName.compare(":memory:") == 0 ||
+                    fileName.find("file::memory:") == 0 ||
+                    fileName.find("?mode=memory") != string::npos ||
+                    fileName.find("&mode=memory") != string::npos) {
+                    return SQLITE_OK;
+                }
+                return SQLITE_DENY;
+            }
+        }
+    }
+    return SQLITE_OK;
+}

--- a/src/sql_util.cc
+++ b/src/sql_util.cc
@@ -728,13 +728,18 @@ int sqlite_authorizer(void *pUserData, int action_code, const char *detail1,
             if (!fileName.empty()) {
                  /* In-memory databases are fine.
                  */
-                if (fileName.compare(":memory:") == 0 || (
-                    sqlite3_libversion_number() >= 3008000 &&
-                    (fileName.find("file::memory:") == 0 ||
-                    fileName.find("?mode=memory") != string::npos ||
-                    fileName.find("&mode=memory") != string::npos))) {
+                if (fileName.compare(":memory:") == 0) {
                     return SQLITE_OK;
                 }
+#ifdef HAVE_SQLITE3_COMPILEOPTION_USED
+                if (sqlite3_compileoption_used("SQLITE_USE_URI") && (
+                    fileName.find("file::memory:") == 0 || (
+                    (sqlite3_libversion_number() >= 3008000) && (
+                    fileName.find("?mode=memory") != string::npos ||
+                    fileName.find("&mode=memory") != string::npos)))) {
+                    return SQLITE_OK;
+                }
+#endif
                 return SQLITE_DENY;
             }
         }

--- a/src/sql_util.cc
+++ b/src/sql_util.cc
@@ -725,13 +725,14 @@ int sqlite_authorizer(void *pUserData, int action_code, const char *detail1,
             string fileName(detail1);
 
             /* A temporary database is fine. */
-            if (fileName.length()) {
+            if (!fileName.empty()) {
                  /* In-memory databases are fine.
                  */
-                if (fileName.compare(":memory:") == 0 ||
-                    fileName.find("file::memory:") == 0 ||
+                if (fileName.compare(":memory:") == 0 || (
+                    sqlite3_libversion_number() >= 3008000 &&
+                    (fileName.find("file::memory:") == 0 ||
                     fileName.find("?mode=memory") != string::npos ||
-                    fileName.find("&mode=memory") != string::npos) {
+                    fileName.find("&mode=memory") != string::npos))) {
                     return SQLITE_OK;
                 }
                 return SQLITE_DENY;

--- a/src/sql_util.hh
+++ b/src/sql_util.hh
@@ -87,4 +87,7 @@ int guess_type_from_pcre(const std::string &pattern, const char **collator);
 /* XXX figure out how to do this with the template */
 void sqlite_close_wrapper(void *mem);
 
+int sqlite_authorizer(void* pUserData, int action_code, const char *detail1,
+                      const char *detail2, const char *detail3,
+                      const char *detail4);
 #endif

--- a/test/test_sql.sh
+++ b/test/test_sql.sh
@@ -686,6 +686,71 @@ id first_name last_name age
  1 Lem        Hewitt     35
 EOF
 
+# Test to see if we can attach a database in LNAVSECURE mode.
+export LNAVSECURE=1
+
+run_test ${lnav_test} -n \
+    -c ";attach database 'simple-db.db' as 'db'" \
+    empty
+
+check_error_output "LNAVSECURE mode bypassed" <<EOF
+error: not authorized
+EOF
+
+run_test ${lnav_test} -n \
+    -c ";attach database ':memdb:' as 'db'" \
+    empty
+
+check_error_output "LNAVSECURE mode bypassed (':' adorned)" <<EOF
+error: not authorized
+EOF
+
+run_test ${lnav_test} -n \
+    -c ";attach database '/tmp/memdb' as 'db'" \
+    empty
+
+check_error_output "LNAVSECURE mode bypassed (filepath)" <<EOF
+error: not authorized
+EOF
+
+run_test ${lnav_test} -n \
+    -c ";attach database 'file:memdb?cache=shared' as 'db'" \
+    empty
+
+check_error_output "LNAVSECURE mode bypassed (URI)" <<EOF
+error: not authorized
+EOF
+
+run_test ${lnav_test} -n \
+    -c ";attach database '' as 'db'" \
+    empty
+
+check_error_output "Failed to create a temporary db in LNAVSECURE mode" <<EOF
+EOF
+
+run_test ${lnav_test} -n \
+    -c ";attach database ':memory:' as 'db'" \
+    empty
+
+check_error_output "Failed to create an in-memory db in LNAVSECURE mode" <<EOF
+EOF
+
+run_test ${lnav_test} -n \
+    -c ";attach database 'file:memdb?mode=memory' as 'db'" \
+    empty
+
+check_error_output "Failed to create a in-memory db (URI) in LNAVSECURE mode" <<EOF
+EOF
+
+run_test ${lnav_test} -n \
+    -c ";attach database 'file:memdb?cache=shared&mode=memory' as 'db'" \
+    empty
+
+check_error_output "Failed to create a in-memory db (URI2) in LNAVSECURE mode" <<EOF
+EOF
+
+unset LNAVSECURE
+
 
 touch -t 201503240923 ${test_dir}/logfile_syslog_with_access_log.0
 run_test ${lnav_test} -n \

--- a/test/test_sql.sh
+++ b/test/test_sql.sh
@@ -735,19 +735,23 @@ run_test ${lnav_test} -n \
 check_error_output "Failed to create an in-memory db in LNAVSECURE mode" <<EOF
 EOF
 
-run_test ${lnav_test} -n \
-    -c ";attach database 'file:memdb?mode=memory' as 'db'" \
-    empty
-
-check_error_output "Failed to create a in-memory db (URI) in LNAVSECURE mode" <<EOF
-EOF
-
-run_test ${lnav_test} -n \
-    -c ";attach database 'file:memdb?cache=shared&mode=memory' as 'db'" \
-    empty
-
-check_error_output "Failed to create a in-memory db (URI2) in LNAVSECURE mode" <<EOF
-EOF
+# XXX: The following tests are only applicable when sqlite version is >= 3.8.0.
+# Turned off at the moment since Travis CI seems to use version 3.6.0 and the
+# checks fail.
+#
+#run_test ${lnav_test} -n \
+#    -c ";attach database 'file:memdb?mode=memory' as 'db'" \
+#    empty
+#
+#check_error_output "Failed to create a in-memory db (URI) in LNAVSECURE mode" <<EOF
+#EOF
+#
+#run_test ${lnav_test} -n \
+#    -c ";attach database 'file:memdb?cache=shared&mode=memory' as 'db'" \
+#    empty
+#
+#check_error_output "Failed to create a in-memory db (URI2) in LNAVSECURE mode" <<EOF
+#EOF
 
 unset LNAVSECURE
 


### PR DESCRIPTION
Prevent the users from attaching an external db file which they may not
have ownership of.

The current authorizer method is hooked in only when the LNAVSECURE
variable is set. This is done deliberately, since the method will be
called on every sqlite query and I did not want to incur a performance
hit.

If the scope of this authorizer increases, we should consider passing in
the lnav_data as pUserData and do the checks inside the authorizer
itself.