### PR TITLE
[secure-mode] Disallow ATTACH statements completely.

### DIFF
--- a/m4/lnav_with_sqlite3.m4
+++ b/m4/lnav_with_sqlite3.m4
@@ -95,12 +95,6 @@ AC_DEFUN([LNAV_WITH_SQLITE3],
         )
     )
 
-    AC_CHECK_FUNC(sqlite3_compileoption_used,
-        AC_DEFINE([HAVE_SQLITE3_COMPILEOPTION_USED], [],
-            [Have sqlite3_compileoption_used function]
-        )
-    )
-
     AC_SUBST(HAVE_SQLITE3_VALUE_SUBTYPE)
 
     AS_VAR_SET(CFLAGS, $saved_CFLAGS)

--- a/src/sql_util.cc
+++ b/src/sql_util.cc
@@ -720,29 +720,7 @@ int sqlite_authorizer(void *pUserData, int action_code, const char *detail1,
 {
     if (action_code == SQLITE_ATTACH)
     {
-        /* Check to see that the filename is not NULL */
-        if (detail1 != NULL) {
-            string fileName(detail1);
-
-            /* A temporary database is fine. */
-            if (!fileName.empty()) {
-                 /* In-memory databases are fine.
-                 */
-                if (fileName.compare(":memory:") == 0) {
-                    return SQLITE_OK;
-                }
-#ifdef HAVE_SQLITE3_COMPILEOPTION_USED
-                if (sqlite3_compileoption_used("SQLITE_USE_URI") && (
-                    fileName.find("file::memory:") == 0 || (
-                    (sqlite3_libversion_number() >= 3008000) && (
-                    fileName.find("?mode=memory") != string::npos ||
-                    fileName.find("&mode=memory") != string::npos)))) {
-                    return SQLITE_OK;
-                }
-#endif
-                return SQLITE_DENY;
-            }
-        }
+        return SQLITE_DENY;
     }
     return SQLITE_OK;
 }

--- a/test/test_sql.sh
+++ b/test/test_sql.sh
@@ -721,38 +721,6 @@ check_error_output "LNAVSECURE mode bypassed (URI)" <<EOF
 error: not authorized
 EOF
 
-run_test ${lnav_test} -n \
-    -c ";attach database '' as 'db'" \
-    empty
-
-check_error_output "Failed to create a temporary db in LNAVSECURE mode" <<EOF
-EOF
-
-run_test ${lnav_test} -n \
-    -c ";attach database ':memory:' as 'db'" \
-    empty
-
-check_error_output "Failed to create an in-memory db in LNAVSECURE mode" <<EOF
-EOF
-
-# XXX: The following tests are only applicable when sqlite version is >= 3.8.0.
-# Turned off at the moment since Travis CI seems to use version 3.6.0 and the
-# checks fail.
-#
-#run_test ${lnav_test} -n \
-#    -c ";attach database 'file:memdb?mode=memory' as 'db'" \
-#    empty
-#
-#check_error_output "Failed to create a in-memory db (URI) in LNAVSECURE mode" <<EOF
-#EOF
-#
-#run_test ${lnav_test} -n \
-#    -c ";attach database 'file:memdb?cache=shared&mode=memory' as 'db'" \
-#    empty
-#
-#check_error_output "Failed to create a in-memory db (URI2) in LNAVSECURE mode" <<EOF
-#EOF
-
 unset LNAVSECURE
 
 


### PR DESCRIPTION
The code to handle in-memory db exceptions is hideous and unreliable,
given the fact that SQLite does not expose much in terms of getting the
current value and the methods to check the compile time options can
themselves be disabled by a compile=time option in SQLite.

There really isn't much use for in-memory databases and if someone
really needs it, they can always choose to run in normal mode, so just
remove the extra code.