### PR TITLE
Add cygwin continuous integration through appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/tstack/lnav.png)](https://travis-ci.org/tstack/lnav)
+[![Build status](https://ci.appveyor.com/api/projects/status/244vvhr6a5hh7dbw?svg=true)](https://ci.appveyor.com/project/saaguero/lnav)
 [![Bounties](https://img.shields.io/bountysource/team/lnav/activity.svg)](https://www.bountysource.com/teams/lnav)
 
 _This is the source repository for **lnav**, visit [http://lnav.org](http://lnav.org) for a high level overview._
@@ -40,6 +41,21 @@ Lnav follows the usual GNU style for configuring and installing software:
 
 __Run ```./autogen.sh``` before running any of the above commands when
 compiling from a cloned repository.__
+
+
+Cygwin users
+------------
+
+It should compile fine in Cygwin.
+
+Alternatively, you can get the generated binary from [AppVeyor](https://ci.appveyor.com/project/saaguero/lnav) artifacts.
+
+Remember that you still need the lnav dependencies under Cygwin, here is a quick way to do it:
+
+`setup-x86_64.exe -q -P libpcre1 -P libpcrecpp0 -P libsqlite3_0 -P libstdc++6`
+
+Currently, the x64 version seems to be working better than the x86 one.
+
 
 Using
 -----

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+version: "{build}"
+
+environment:
+  matrix:
+  - cygwin: cygwin
+    cygsetup: setup-x86.exe
+  - cygwin: cygwin64
+    cygsetup: setup-x86_64.exe
+
+install:
+  - C:\%cygwin%\%cygsetup% -qnNdO -R C:/%cygwin% -s http://cygwin.mirror.constant.com -l C:/%cygwin%/var/cache/setup -P libpcre-devel -P libncurses-devel -P libreadline-devel -P zlib-devel -P libbz2-devel -P libsqlite3-devel
+
+build_script:
+  - C:\%cygwin%\bin\sh -lc "uname -a && gcc --version && cd /cygdrive/c/projects/lnav && ./autogen.sh && ./configure && make && strip src/lnav.exe && ldd src/lnav.exe"
+
+artifacts:
+  - path: src\lnav.exe
+    name: lnav.exe


### PR DESCRIPTION
This should resolve (at least with Cygwin) the issue https://github.com/tstack/lnav/issues/204

Please note that you will need to create an AppVeyor account, import your tstack/lnav project and then edit the README.md links accordingly.