### PR TITLE
[fmt] Fix glog_log format

### DIFF
--- a/src/default-log-formats.json
+++ b/src/default-log-formats.json
@@ -436,7 +436,7 @@
         "url" : "https://code.google.com/p/google-glog/",
         "regex" : {
             "std" : {
-                "pattern" : "^(?<level>[IWECF])(?<timestamp>\\d{4} \\d{2}:\\d{2}:\\d{2}\\.\\d{6}) (?<thread>\\d+) (?<src_file>[^:]+):(?<src_line>\\d+)\\] (?<body>(?:.|\\n)*)"
+                "pattern" : "^(?<level>[IWECF])(?<timestamp>\\d{4} \\d{2}:\\d{2}:\\d{2}\\.\\d{6}) +(?<thread>\\d+) (?<src_file>[^:]+):(?<src_line>\\d+)\\] (?<body>(?:.|\\n)*)"
             }
         },
         "level-field" : "level",
@@ -465,7 +465,8 @@
         },
         "sample" : [
             {
-                "line" : "E0517 15:04:22.619632 1952452992 logging_unittest.cc:253] Log every 3, iteration 19"
+                "line" : "E0517 15:04:22.619632 1952452992 logging_unittest.cc:253] Log every 3, iteration 19",
+                "line" : "E0517 15:04:22.619632      52992 logging_unittest.cc:253] Log every 3, iteration 19"
             }
         ]
     },

--- a/test/logfile_glog.0
+++ b/test/logfile_glog.0
@@ -1,7 +1,7 @@
 E0517 15:04:22.619632 1952452992 logging_unittest.cc:253] Log every 3, iteration 19
-I0517 15:04:22.619642 1952452992 logging_unittest.cc:259] Log if every 1, iteration 19
-I0517 15:04:22.619740 1952452992 logging_unittest.cc:259] Log if every 1, iteration 20
-W0517 15:04:22.619751 1952452992 logging_unittest.cc:263] log_if this
-I0517 15:04:22.619760 1952452992 logging_unittest.cc:267] array
-I0517 15:04:22.619768 1952452992 logging_unittest.cc:269] const array
-E0517 15:04:22.619776 1952452992 logging_unittest.cc:271] foo 1000 0000001000 3e8
+I0517 15:04:22.619642  952452992 logging_unittest.cc:259] Log if every 1, iteration 19
+I0517 15:04:22.619740   52452992 logging_unittest.cc:259] Log if every 1, iteration 20
+W0517 15:04:22.619751    2452992 logging_unittest.cc:263] log_if this
+I0517 15:04:22.619760     452992 logging_unittest.cc:267] array
+I0517 15:04:22.619768      52992 logging_unittest.cc:269] const array
+E0517 15:04:22.619776       2992 logging_unittest.cc:271] foo 1000 0000001000 3e8


### PR DESCRIPTION
The log format used by glog uses spaces to left-pad the thread to 7 digits, [per the code](https://github.com/golang/glog/blob/65d6746/glog.go#L577):
```go
buf.nDigits(7, 22, pid, ' ') // TODO: should be TID
```
This fixes the regular expression to correctly match the extra whitespace.