### PR TITLE
[freebsd] Partial fix for the release builds.

### DIFF
--- a/release/vagrant-static/build.sh
+++ b/release/vagrant-static/build.sh
@@ -35,8 +35,8 @@ OS=$(uname -s)
 if test x"${OS}" != x"FreeBSD"; then
     ../lnav/configure \
         LDFLAGS="-L${FAKE_ROOT}/lib" \
-        CC="gcc44" \
-        CXX="g++44" \
+        CC="gcc48" \
+        CXX="g++48" \
         CPPFLAGS="-I${FAKE_ROOT}/include" \
         PATH="${FAKE_ROOT}/bin:${PATH}"
 else

--- a/release/vagrant-static/build.sh
+++ b/release/vagrant-static/build.sh
@@ -48,6 +48,8 @@ fi
 
 make -j2 && strip -o /vagrant/lnav src/lnav
 
-mkdir instdir
-make install-strip DESTDIR=$PWD/instdir
-(cd instdir/ && zip -r /vagrant/lnav-linux.zip .)
+if test x"${OS}" != x"FreeBSD"; then
+    mkdir instdir
+    make install-strip DESTDIR=$PWD/instdir
+    (cd instdir/ && zip -r /vagrant/lnav-linux.zip .)
+fi

--- a/release/vagrant-static/provision.sh
+++ b/release/vagrant-static/provision.sh
@@ -55,7 +55,7 @@ OS=$(uname -s)
 (cd bzip2-1.0.6 && make install PREFIX=${FAKE_ROOT})
 
 (cd sqlite-* &&
- ./configure --prefix=${FAKE_ROOT} \
+ ./configure --disable-editline --prefix=${FAKE_ROOT} \
      CFLAGS="${SQLITE_CFLAGS}" \
      && \
  make && make install)


### PR DESCRIPTION
The default gcc toolchain on freebsd has been bumped to 4.8 so the build
scripts that hardcoded the gcc binary name are getting confused.

The new version of SQLite seems to be getting confused between editline
and readline.