### PR TITLE
Add Ctrl-W display shortcut for word-wrap.

### DIFF
--- a/docs/source/hotkeys.rst
+++ b/docs/source/hotkeys.rst
@@ -214,6 +214,9 @@ Display
    * - |ks| Ctrl |ke| + |ks| l |ke|
      - Switch to lo-fi mode.  The displayed log lines will be dumped to the
        terminal without any decorations so they can be copied easily.
+   * - |ks| Ctrl |ke| + |ks| w |ke|
+     - Toggle word-wrap.
+
 
 Session
 -------


### PR DESCRIPTION
This is mentioned in the lnav 0.6.2 release notes:

http://lnav.org/blog/2013/11/10/word-wrap-support-in-v062

But doesn't appear to be mentioned elsewhere.