### PR TITLE
fix compile on SUSE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,11 +13,11 @@ for defdir in /opt/local /usr/local /usr /; do
         CPPFLAGS="$CPPFLAGS -I$defdir/include"
     fi
 
-    if test -d "$defdir/lib"; then
-        LDFLAGS="$LDFLAGS -L$defdir/lib"
-    fi
     if test -d "$defdir/lib64"; then
         LDFLAGS="$LDFLAGS -L$defdir/lib64"
+    fi
+    if test -d "$defdir/lib"; then
+        LDFLAGS="$LDFLAGS -L$defdir/lib"
     fi
 
     if test -d "$defdir/lib/x86_64-linux-gnu"; then


### PR DESCRIPTION
If we have both 64-bit and 32-bit versions of ncurses installed, currently the 32-bit libraries in `/lib` get found first, so `gcc` fails to link against them, and `./configure` ends up thinking that we're missing `ncurses` libraries.

So scan `/lib64` before `/lib`.  There might be a better fix, but hopefully it will avoid breaking 32-bit distributions and distributions which have 64-bit libraries in `/lib`.