### PR TITLE
Add new '.' hotkey to toggle display of logfile names

### DIFF
--- a/docs/source/hotkeys.rst
+++ b/docs/source/hotkeys.rst
@@ -209,6 +209,8 @@ Display
        log_line column
    * - |ks| p |ke|
      - Toggle the display of the log parser results
+   * - |ks| . |ke|
+     - Toggle the display of the log file names
    * - |ks| Tab |ke|
      - Cycle through colums to graph in the SQL result view
    * - |ks| Ctrl |ke| + |ks| l |ke|

--- a/src/filesystem/path.h
+++ b/src/filesystem/path.h
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <cctype>
 #include <cstdlib>
+#include <cstdio>
 #include <cerrno>
 #include <cstring>
 

--- a/src/help.txt
+++ b/src/help.txt
@@ -295,6 +295,9 @@ Display options
                     means it has sped up.  You can use the "s/S" hotkeys to
                     scan through the slow downs.
 
+  .                 In the log view, toggle the display of filenames showing
+                    where each log line comes from.
+
   i                 View/leave a histogram of the log messages over
                     time.  The histogram counts the number of
                     displayed log lines for each bucket of time.  The

--- a/src/hotkeys.cc
+++ b/src/hotkeys.cc
@@ -1029,6 +1029,11 @@ void handle_paging_key(int ch)
             tc->reload_data();
             break;
 
+        case '.':
+            lnav_data.ld_log_source.toggle_filename();
+            tc->reload_data();
+            break;
+
         case 'i':
             if (toggle_view(&lnav_data.ld_views[LNV_HISTOGRAM])) {
                 lss->text_filters_changed();

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -390,7 +390,7 @@ public:
         }
 
         if (!lnav_data.ld_looping) {
-            throw logfile::error(lf.get_filename(), EINTR);
+            throw logfile::error(lf.get_filepath(), EINTR);
         }
     };
 
@@ -468,9 +468,9 @@ public:
     textfile_callback() : force(false), front_file(NULL), front_top(-1) { };
 
     void closed_file(logfile *lf) {
-        log_info("closed text file: %s", lf->get_filename().c_str());
-        if (!lf->is_valid_filename()) {
-            lnav_data.ld_file_names.erase(lf->get_filename());
+        log_info("closed text file: %s", lf->get_filepath().c_str());
+        if (!lf->is_valid_filepath()) {
+            lnav_data.ld_file_names.erase(lf->get_filepath());
         }
         lnav_data.ld_files.remove(lf);
         delete lf;
@@ -488,7 +488,7 @@ public:
     void scanned_file(logfile *lf) {
         if (!lnav_data.ld_files_to_front.empty() &&
                 lnav_data.ld_files_to_front.front().first ==
-                        lf->get_filename()) {
+                        lf->get_filepath()) {
             this->front_file = lf;
             this->front_top = lnav_data.ld_files_to_front.front().second;
 
@@ -576,9 +576,9 @@ void rebuild_indexes(bool force)
         logfile *lf = *file_iter;
 
         if (!lf->exists() || lf->is_closed()) {
-            log_info("closed log file: %s", lf->get_filename().c_str());
-            if (!lf->is_valid_filename()) {
-                lnav_data.ld_file_names.erase(lf->get_filename());
+            log_info("closed log file: %s", lf->get_filepath().c_str());
+            if (!lf->is_valid_filepath()) {
+                lnav_data.ld_file_names.erase(lf->get_filepath());
             }
             lnav_data.ld_text_source.remove(lf);
             lnav_data.ld_log_source.remove_file(lf);
@@ -1349,7 +1349,7 @@ static bool watch_logfile(string filename, logfile_open_options &loo, bool requi
         /* The file is already loaded, but has been found under a different
          * name.  We just need to update the stored file name.
          */
-        (*file_iter)->set_filename(filename);
+        (*file_iter)->set_filepath(filename);
     }
 
     return retval;
@@ -1430,7 +1430,7 @@ bool rescan_files(bool required)
 
         if (!lf->exists() || lf->is_closed()) {
             log_info("Log file no longer exists or is closed: %s",
-                     lf->get_filename().c_str());
+                     lf->get_filepath().c_str());
             return true;
         }
         else {
@@ -1482,7 +1482,7 @@ static string execute_action(log_data_helper &ldh,
             int value_line;
             string path;
 
-            setenv("LNAV_ACTION_FILE", lf->get_filename().c_str(), 1);
+            setenv("LNAV_ACTION_FILE", lf->get_filepath().c_str(), 1);
             snprintf(env_buffer, sizeof(env_buffer),
                 "%ld",
                 (ldh.ldh_line - lf->begin()) + 1);
@@ -3037,7 +3037,7 @@ int main(int argc, char *argv[])
             log_format *fmt = lf->get_format();
             if (fmt == NULL) {
                 fprintf(stderr, "error:%s:no format found for file\n",
-                        lf->get_filename().c_str());
+                        lf->get_filepath().c_str());
                 retval = EXIT_FAILURE;
                 continue;
             }
@@ -3059,22 +3059,22 @@ int main(int argc, char *argv[])
 
                     fprintf(stderr,
                             "error:%s:%ld:line did not match format %s\n",
-                            lf->get_filename().c_str(), line_number,
+                            lf->get_filepath().c_str(), line_number,
                             fmt->get_pattern_name().c_str());
                     fprintf(stderr,
                             "error:%s:%ld:         line -- %s\n",
-                            lf->get_filename().c_str(), line_number,
+                            lf->get_filepath().c_str(), line_number,
                             full_line.c_str());
                     if (partial_len > 0) {
                         fprintf(stderr,
                                 "error:%s:%ld:partial match -- %s\n",
-                                lf->get_filename().c_str(), line_number,
+                                lf->get_filepath().c_str(), line_number,
                                 partial_line.c_str());
                     }
                     else {
                         fprintf(stderr,
                                 "error:%s:%ld:no partial match found\n",
-                                lf->get_filename().c_str(), line_number);
+                                lf->get_filepath().c_str(), line_number);
                     }
                     retval = EXIT_FAILURE;
                 }

--- a/src/lnav_commands.cc
+++ b/src/lnav_commands.cc
@@ -89,7 +89,7 @@ static string refresh_pt_search()
          ++iter) {
         logfile *lf = *iter;
 
-        if (startswith(lf->get_filename(), "pt:")) {
+        if (startswith(lf->get_filepath(), "pt:")) {
             lf->close();
         }
     }
@@ -727,7 +727,7 @@ static string com_pipe_to(exec_context &ec, string cmdline, vector<string> &args
                 setenv("log_line", tmp_str, 1);
                 sql_strftime(tmp_str, sizeof(tmp_str), ldh.ldh_line->get_timeval());
                 setenv("log_time", tmp_str, 1);
-                setenv("log_path", ldh.ldh_file->get_filename().c_str(), 1);
+                setenv("log_path", ldh.ldh_file->get_filepath().c_str(), 1);
                 for (vector<logline_value>::iterator iter = ldh.ldh_line_values.begin();
                      iter != ldh.ldh_line_values.end();
                      ++iter) {
@@ -1368,7 +1368,7 @@ static string com_open(exec_context &ec, string cmdline, vector<string> &args)
              ++file_iter) {
             logfile *lf = *file_iter;
 
-            if (lf->get_filename() == fn) {
+            if (lf->get_filepath() == fn) {
                 if (lf->get_format() != NULL) {
                     retval = "info: log file already loaded";
                     break;
@@ -1482,7 +1482,7 @@ static string com_close(exec_context &ec, string cmdline, vector<string> &args)
                 retval = "error: no text files are opened";
             }
             else {
-                fn = tss.current_file()->get_filename();
+                fn = tss.current_file()->get_filepath();
                 tss.current_file()->close();
 
                 if (tss.size() == 1) {
@@ -1500,7 +1500,7 @@ static string com_close(exec_context &ec, string cmdline, vector<string> &args)
                 content_line_t cl = lss.at(vl);
                 logfile *lf = lss.find(cl);
 
-                fn = lf->get_filename();
+                fn = lf->get_filepath();
                 lf->close();
             }
         }

--- a/src/log_vtab_impl.cc
+++ b/src/log_vtab_impl.cc
@@ -380,7 +380,7 @@ static int vt_column(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col)
 
             switch (post_col_number) {
                 case 0: {
-                    const string &fn = lf->get_filename();
+                    const string &fn = lf->get_filepath();
 
                     sqlite3_result_text(ctx,
                                         fn.c_str(),

--- a/src/logfile.hh
+++ b/src/logfile.hh
@@ -48,6 +48,7 @@
 #include "log_format.hh"
 #include "text_format.hh"
 #include "shared_buffer.hh"
+#include "filesystem/path.h"
 
 class logfile;
 class logline_observer;
@@ -137,12 +138,17 @@ public:
     /** @return The filepath as given in the constructor. */
     const std::string &get_filepath() const { return this->lf_filepath; };
 
+    /** @return The filename as given in the constructor, excluding the path prefix. */
+    const std::string &get_filename() const { return this->lf_filename; };
+
     int get_fd() const { return this->lf_line_buffer.get_fd(); };
 
     /** @param filepath The new filepath for this log file. */
     void set_filepath(const std::string &filepath)
     {
         this->lf_filepath = filepath;
+        filesystem::path p(filepath);
+        this->lf_filename = p.filename();
     };
 
     const std::string &get_content_id() const { return this->lf_content_id; };
@@ -399,6 +405,7 @@ protected:
     logfile_activity lf_activity;
     bool        lf_valid_filepath;
     std::string lf_filepath;
+    std::string lf_filename;
     std::string lf_content_id;
     struct stat lf_stat;
     std::unique_ptr<log_format> lf_format;

--- a/src/logfile.hh
+++ b/src/logfile.hh
@@ -121,12 +121,12 @@ public:
     /**
      * Construct a logfile with the given arguments.
      *
-     * @param filename The name of the log file.
+     * @param filepath The name of the log file.
      * @param fd The file descriptor for accessing the file or -1 if the
-     * constructor should open the file specified by 'filename'.  The
+     * constructor should open the file specified by 'filepath'.  The
      * descriptor needs to be seekable.
      */
-    logfile(const std::string &filename, logfile_open_options &loo) throw (error);
+    logfile(const std::string &filepath, logfile_open_options &loo) throw (error);
 
     virtual ~logfile();
 
@@ -134,15 +134,15 @@ public:
         return this->lf_activity;
     };
 
-    /** @return The filename as given in the constructor. */
-    const std::string &get_filename() const { return this->lf_filename; };
+    /** @return The filepath as given in the constructor. */
+    const std::string &get_filepath() const { return this->lf_filepath; };
 
     int get_fd() const { return this->lf_line_buffer.get_fd(); };
 
-    /** @param filename The new filename for this log file. */
-    void set_filename(const std::string &filename)
+    /** @param filepath The new filepath for this log file. */
+    void set_filepath(const std::string &filepath)
     {
-        this->lf_filename = filename;
+        this->lf_filepath = filepath;
     };
 
     const std::string &get_content_id() const { return this->lf_content_id; };
@@ -158,8 +158,8 @@ public:
         return this->lf_line_buffer.is_compressed();
     };
 
-    bool is_valid_filename() const {
-        return this->lf_valid_filename;
+    bool is_valid_filepath() const {
+        return this->lf_valid_filepath;
     };
 
     /**
@@ -377,7 +377,7 @@ public:
     /** Check the invariants for this object. */
     bool invariant(void)
     {
-        require(this->lf_filename.size() > 0);
+        require(this->lf_filepath.size() > 0);
 
         return true;
     };
@@ -397,8 +397,8 @@ protected:
 
     logfile_open_options lf_options;
     logfile_activity lf_activity;
-    bool        lf_valid_filename;
-    std::string lf_filename;
+    bool        lf_valid_filepath;
+    std::string lf_filepath;
     std::string lf_content_id;
     struct stat lf_stat;
     std::unique_ptr<log_format> lf_format;

--- a/src/logfile_sub_source.cc
+++ b/src/logfile_sub_source.cc
@@ -71,7 +71,7 @@ logfile *logfile_sub_source::find(const char *fn,
         if (ld.get_file() == NULL) {
             continue;
         }
-        if (strcmp(ld.get_file()->get_filename().c_str(), fn) == 0) {
+        if (strcmp(ld.get_file()->get_filepath().c_str(), fn) == 0) {
             retval = ld.get_file();
         }
         else {
@@ -335,7 +335,7 @@ void logfile_sub_source::text_attrs_for_line(textview_curses &lv,
         }
     }
     value_out.push_back(string_attr(lr, &view_curses::VC_STYLE, vc.attrs_for_ident(
-        this->lss_token_file->get_filename())));
+        this->lss_token_file->get_filepath())));
 
     if (this->lss_flags & F_TIME_OFFSET) {
         time_offset_end = 13;

--- a/src/logfile_sub_source.cc
+++ b/src/logfile_sub_source.cc
@@ -195,6 +195,11 @@ void logfile_sub_source::text_value_for_line(textview_curses &tc,
         }
     }
 
+    if (this->lss_flags & F_FILENAME) {
+        value_out.insert(0, 1, ' ');
+        value_out.insert(0, this->lss_token_file->get_filename());
+    }
+
     // Insert space for the file/search-hit markers.
     value_out.insert(0, 1, ' ');
 

--- a/src/logfile_sub_source.hh
+++ b/src/logfile_sub_source.hh
@@ -97,6 +97,11 @@ public:
         this->clear_line_size_cache();
     };
 
+    void toggle_filename(void) {
+        this->lss_flags ^= F_FILENAME;
+        this->clear_line_size_cache();
+    };
+
     void set_time_offset(bool enabled) {
         if (enabled)
             this->lss_flags |= F_TIME_OFFSET;
@@ -107,6 +112,10 @@ public:
 
     bool is_time_offset_enabled(void) const {
         return (bool) (this->lss_flags & F_TIME_OFFSET);
+    };
+
+    bool is_filename_enabled(void) const {
+        return (bool) (this->lss_flags & F_FILENAME);
     };
 
     logline::level_t get_min_log_level(void) const {
@@ -459,11 +468,13 @@ private:
     enum {
         B_SCRUB,
         B_TIME_OFFSET,
+        B_FILENAME,
     };
 
     enum {
         F_SCRUB       = (1L << B_SCRUB),
         F_TIME_OFFSET = (1L << B_TIME_OFFSET),
+        F_FILENAME    = (1L << B_FILENAME),
     };
 
     struct __attribute__((__packed__)) indexed_content {

--- a/src/session_data.cc
+++ b/src/session_data.cc
@@ -552,7 +552,7 @@ static void load_time_bookmarks(void)
         if (lf == NULL)
             continue;
 
-        lss.find(lf->get_filename().c_str(), base_content_line);
+        lss.find(lf->get_filepath().c_str(), base_content_line);
 
         logfile::iterator line_iter = lf->begin();
 

--- a/src/term_extra.hh
+++ b/src/term_extra.hh
@@ -84,7 +84,7 @@ public:
             line_attr = find_string_attr(sa, &logline::L_FILE);
             if (line_attr != sa.end()) {
                 logfile *lf = (logfile *)line_attr->sa_value.sav_ptr;
-                const std::string &filename = lf->get_filename();
+                const std::string &filename = lf->get_filepath();
 
                 if (filename != this->te_last_title) {
                     std::string title = this->te_prefix + filename;

--- a/src/textfile_sub_source.hh
+++ b/src/textfile_sub_source.hh
@@ -123,7 +123,7 @@ public:
             return "";
         }
 
-        return this->tss_files.front()->get_filename();
+        return this->tss_files.front()->get_filepath();
     };
 
     void to_front(logfile *lf) {

--- a/src/top_status_source.hh
+++ b/src/top_status_source.hh
@@ -121,14 +121,14 @@ public:
                     sf_format.set_value("% 13s",
                                         lf->get_format()->get_name().get());
                 }
-                else if (!lf->get_filename().empty()) {
+                else if (!lf->get_filepath().empty()) {
                     sf_format.set_value("% 13s", "plain text");
                 }
                 else{
                     sf_format.clear();
                 }
 
-                sf_filename.set_value(lf->get_filename());
+                sf_filename.set_value(lf->get_filepath());
             }
             else {
                 sf_format.clear();

--- a/test/drive_logfile.cc
+++ b/test/drive_logfile.cc
@@ -109,7 +109,7 @@ int main(int argc, char *argv[]) {
       struct stat st;
 
       stat(argv[0], &st);
-      assert(strcmp(argv[0], lf.get_filename().c_str()) == 0);
+      assert(strcmp(argv[0], lf.get_filepath().c_str()) == 0);
 
       lf.rebuild_index();
       assert(!lf.is_closed());


### PR DESCRIPTION
Mostly addresses #277.  I won't claim it fully closes it, because there are several ways it needs to be improved:

1.  It doesn't draw a nice coloured divider in the column after the filename, and that would provide maximum visual clarity and consistency with the existing presentation.
2.  It would be nice if the filenames weren't shown on every single line, but only on the first line of a contiguous chunk of log lines from a single file (or on the top line of the screen if the first line of the chunk was already scrolled off the top).
3.  It doesn't yet include the filename in the text copied to the clipboard when the 'c' hotkey is pressed.
4.  It doesn't correctly extend the line length to include the filename, when `Control+L` is pressed to get lo-fi mode.

The main reason I didn't solve these is that I have zero experience of `ncurses` (and honestly, very little of C++ too), so I've been struggling to understand how the display code actually works.  Any hints very welcome, although personally I think it would be OK to address these shortcomings in a separate pull request later.

BTW, `x` was the only letter not yet bound to a hotkey AFAICS.