### PR TITLE
fix hints about moving by hour

### DIFF
--- a/src/hotkeys.cc
+++ b/src/hotkeys.cc
@@ -316,8 +316,8 @@ void handle_paging_key(int ch)
                            &logfile_sub_source::BM_WARNINGS,
                            tc->get_top());
             lnav_data.ld_rl_view->set_alt_value(HELP_MSG_2(
-                    o, O,
-                    "to move forward/backward an hour"));
+                    6, ^,
+                    "to move to next/previous hour boundary"));
             break;
 
         case 'W':
@@ -325,8 +325,8 @@ void handle_paging_key(int ch)
                            &logfile_sub_source::BM_WARNINGS,
                            tc->get_top());
             lnav_data.ld_rl_view->set_alt_value(HELP_MSG_2(
-                    o, O,
-                    "to move forward/backward an hour"));
+                    6, ^,
+                    "to move to next/previous hour boundary"));
             break;
 
         case 'n':


### PR DESCRIPTION
`o`/`O` do not move forward/backward an hour; in fact, no hotkey does, but `6`/`^` are about as close as it gets.