### PR TITLE
Fix compile warnings

### DIFF
--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -2404,7 +2404,17 @@ int main(int argc, char *argv[])
                 snprintf(pull_cmd, sizeof(pull_cmd),
                          "cd %s && git pull",
                          git_dir);
-                system(pull_cmd);
+                int ret = system(pull_cmd);
+                if (ret == -1) {
+                    std::cerr << "Failed to spawn command "
+                              << "\"" << pull_cmd << "\": "
+                              << strerror(errno) << std::endl;
+                }
+                else if (ret > 0) {
+                    std::cerr << "Command "
+                              << "\"" << pull_cmd << "\" failed: "
+                              << strerror(errno) << std::endl;
+                }
                 found = true;
             }
         }

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -2355,7 +2355,9 @@ int main(int argc, char *argv[])
         case 'W':
         {
             char b;
-            read(STDIN_FILENO, &b, 1);
+            if (read(STDIN_FILENO, &b, 1) == -1) {
+                perror("Read key from STDIN");
+            }
         }
             break;
 
@@ -2886,8 +2888,11 @@ int main(int argc, char *argv[])
                          ++vl, ++y) {
                         while (los != NULL &&
                                los->list_value_for_overlay(*tc, y, al)) {
-                            write(STDOUT_FILENO, line.c_str(), line.length());
-                            write(STDOUT_FILENO, "\n", 1);
+                            if (write(STDOUT_FILENO, line.c_str(),
+                                      line.length()) == -1 or
+                                write(STDOUT_FILENO, "\n", 1) == -1) {
+                                perror("write to STDOUT");
+                            }
                             ++y;
                         }
 
@@ -2898,9 +2903,11 @@ int main(int argc, char *argv[])
 
                         struct line_range lr = find_string_attr_range(
                                 al.get_attrs(), &textview_curses::SA_ORIGINAL_LINE);
-                        write(STDOUT_FILENO, lr.substr(al.get_string()),
-                              lr.sublen(al.get_string()));
-                        write(STDOUT_FILENO, "\n", 1);
+                        if (write(STDOUT_FILENO, lr.substr(al.get_string()),
+                                  lr.sublen(al.get_string())) == -1 or
+                            write(STDOUT_FILENO, "\n", 1) == -1) {
+                            perror("write to STDOUT");
+                        }
                     }
                 }
             }
@@ -2956,8 +2963,10 @@ int main(int argc, char *argv[])
                      ++line_iter) {
                     lf->read_line(line_iter, str);
 
-                    write(STDOUT_FILENO, str.c_str(), str.size());
-                    write(STDOUT_FILENO, "\n", 1);
+                    if (write(STDOUT_FILENO, str.c_str(), str.size()) == -1 or
+                        write(STDOUT_FILENO, "\n", 1) == -1) {
+                        perror("write to STDOUT");
+                    }
                 }
             }
         }

--- a/src/lnav_commands.cc
+++ b/src/lnav_commands.cc
@@ -64,7 +64,7 @@ static string remaining_args(const string &cmdline,
 
     require(index > 0);
 
-    for (int lpc = 0; lpc < index; lpc++) {
+    for (unsigned int lpc = 0; lpc < index; lpc++) {
         start_pos += args[lpc].length();
     }
 
@@ -571,7 +571,7 @@ static string com_save_to(string cmdline, vector<string> &args)
         dos.list_value_for_overlay(lnav_data.ld_views[LNV_DB], vis_line_t(0), header_line);
         fputs(header_line.get_string().c_str(), outfile);
         fputc('\n', outfile);
-        for (int lpc = 0; lpc < dls.text_line_count(); lpc++) {
+        for (unsigned int lpc = 0; lpc < dls.text_line_count(); lpc++) {
             string line;
 
             dls.text_value_for_line(lnav_data.ld_views[LNV_DB], lpc, line, true);

--- a/src/lnav_log.cc
+++ b/src/lnav_log.cc
@@ -182,8 +182,12 @@ void log_host_info(void)
     log_info("  gid=%d", getgid());
     log_info("  euid=%d", geteuid());
     log_info("  egid=%d", getegid());
-    getcwd(cwd, sizeof(cwd));
-    log_info("  cwd=%s", cwd);
+    if (getcwd(cwd, sizeof(cwd)) == NULL) {
+        log_info("  ERROR: getcwd failed");
+    }
+    else {
+        log_info("  cwd=%s", cwd);
+    }
     log_info("Executable:");
     log_info("  version=%s", VCS_PACKAGE_STRING);
 

--- a/src/lnav_util.cc
+++ b/src/lnav_util.cc
@@ -319,7 +319,7 @@ static time_t BAD_DATE = -1;
 time_t tm2sec(const struct tm *t)
 {
     int       year;
-    time_t    days;
+    time_t    days, secs;
     const int dayoffset[12] =
     { 306, 337, 0, 31, 61, 92, 122, 153, 184, 214, 245, 275 };
 
@@ -341,18 +341,18 @@ time_t tm2sec(const struct tm *t)
     days += dayoffset[t->tm_mon] + t->tm_mday - 1;
     days -= 25508; /* 1 jan 1970 is 25508 days since 1 mar 1900 */
 
-    days = ((days * 24 + t->tm_hour) * 60 + t->tm_min) * 60 + t->tm_sec;
+    secs = ((days * 24 + t->tm_hour) * 60 + t->tm_min) * 60 + t->tm_sec;
 
-    if (days < 0) {
+    if (secs < 0) {
         return BAD_DATE;
     }                          /* must have overflowed */
     else {
 #ifdef HAVE_STRUCT_TM_TM_ZONE
         if (t->tm_zone) {
-            days -= t->tm_gmtoff;
+            secs -= t->tm_gmtoff;
         }
 #endif
-        return days;
+        return secs;
     }                          /* must be a valid time */
 }
 

--- a/src/log_format.hh
+++ b/src/log_format.hh
@@ -1018,8 +1018,8 @@ public:
         json_log_field jfe_type;
         intern_string_t jfe_value;
         std::string jfe_default_value;
-        long long jfe_min_width;
-        long long jfe_max_width;
+        unsigned long long jfe_min_width;
+        unsigned long long jfe_max_width;
         align_t jfe_align;
         overflow_t jfe_overflow;
         std::string jfe_ts_format;

--- a/src/papertrail_proc.hh
+++ b/src/papertrail_proc.hh
@@ -102,9 +102,11 @@ public:
                                                    this->ptp_search.c_str(),
                                                    this->ptp_search.size());
 
-        asprintf(this->ptp_token_header.out(),
-                 "X-Papertrail-Token: %s",
-                 this->ptp_api_key);
+        if (asprintf(this->ptp_token_header.out(),
+                     "X-Papertrail-Token: %s",
+                     this->ptp_api_key) == -1) {
+            perror("Failed to allocate X-Papertrail-Token string");
+        }
         this->ptp_header_list = curl_slist_append(this->ptp_header_list,
                 this->ptp_token_header.in());
 
@@ -140,10 +142,12 @@ public:
                      "max_time=%ld&",
                      this->ptp_max_time);
         }
-        asprintf(this->ptp_url.out(),
-                 "%sq=%s",
-                 base_url,
-                 this->ptp_quoted_search.in());
+        if (asprintf(this->ptp_url.out(),
+                     "%sq=%s",
+                     base_url,
+                     this->ptp_quoted_search.in()) == -1) {
+            perror("Failed to allocate ptp_url");
+        }
         curl_easy_setopt(this->cr_handle, CURLOPT_URL, this->ptp_url.in());
     };
 

--- a/src/ptimec.hh
+++ b/src/ptimec.hh
@@ -381,10 +381,10 @@ inline bool ptime_i(struct exttm *dst, const char *str, off_t &off_inout, ssize_
 
 inline void ftime_i(char *dst, off_t &off_inout, ssize_t len, const struct exttm &tm)
 {
-    uint64_t t = tm2sec(&tm.et_tm);
+    time_t t = tm2sec(&tm.et_tm);
 
     t += tm.et_nsec / 1000000;
-    snprintf(&dst[off_inout], len - off_inout, "%lld", t);
+    snprintf(&dst[off_inout], len - off_inout, "%ld", t);
     off_inout = strlen(dst);
 }
 

--- a/src/relative_time.cc
+++ b/src/relative_time.cc
@@ -219,7 +219,7 @@ bool relative_time::parse(const char *str, size_t len, struct parse_error &pe_ou
 
                     string numstr = pi.get_substr(pc[0]);
 
-                    if (sscanf(numstr.c_str(), "%qd", &number) != 1) {
+                    if (sscanf(numstr.c_str(), "%ld", &number) != 1) {
                         pe_out.pe_msg = "Invalid number: " + numstr;
                         return false;
                     }

--- a/src/url_loader.hh
+++ b/src/url_loader.hh
@@ -76,7 +76,10 @@ public:
             default:
                 log_error("%s:curl failure -- %ld %s",
                           this->cr_name.c_str(), result, curl_easy_strerror(result));
-                write(this->ul_fd, this->cr_error_buffer, strlen(this->cr_error_buffer));
+                if (write(this->ul_fd, this->cr_error_buffer,
+                          strlen(this->cr_error_buffer)) == -1) {
+                    perror("curl failure: write failure");
+                }
                 return -1;
         }
 

--- a/src/yajlpp.hh
+++ b/src/yajlpp.hh
@@ -273,7 +273,7 @@ struct json_path_handler : public json_path_handler_base {
         return *this;
     };
 
-    json_path_handler &for_field(long long *field) {
+    json_path_handler &for_field(unsigned long long *field) {
         this->add_cb(yajlpp_static_number);
         this->jph_simple_offset = field;
         this->jph_validator = yajlpp_validator_for_int;


### PR DESCRIPTION
This fixes a large number of compiler warnings.  There are still quite a few left; almost all of the remaining ones could be fixed with a similar approach but I have already spent way more time on `lnav` than I should have this weekend.

**N.B. These should all be carefully sanity-checked, as I am really a C++ newbie.**