### PR TITLE
add two more common time formats

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,10 +39,12 @@ TIME_FORMATS = \
     "@%@" \
     "%Y-%m-%d %H:%M:%S" \
     "%Y-%m-%d %H:%M:%S%z" \
+    "%Y-%m-%d %H:%M:%S %z" \
     "%Y-%m-%d %H:%M" \
     "%Y-%m-%dT%H:%M:%S.%f%z" \
     "%y-%m-%dT%H:%M:%S.%f%z" \
     "%Y-%m-%dT%H:%M:%SZ" \
+    "%Y-%m-%dT%H:%M:%S%z" \
     "%Y-%m-%dT%H:%M:%S" \
     "%Y-%m-%dT%H:%M:%S%z" \
     "%Y/%m/%d %H:%M:%S" \


### PR DESCRIPTION
Since 26cd9f59 introduced stricter timestamp parsing so that the full string now has to be matched, several of the 3rd party formats installable via `lnav -i extra` broke.  So add a couple more very common timestamp formats to address these.