### PR TITLE
[logfile] Fix format string in debug log.

### DIFF
--- a/src/logfile.cc
+++ b/src/logfile.cc
@@ -93,10 +93,10 @@ throw (error)
 
         loo.loo_fd.close_on_exec();
 
-        log_info("Creating logfile: fd=%d; size=%d; mtime=%d; filename=%s",
+        log_info("Creating logfile: fd=%d; size=%" PRId64 "; mtime=%" PRId64 "; filename=%s",
                  (int) loo.loo_fd,
-                 this->lf_stat.st_size,
-                 this->lf_stat.st_mtime,
+                 (long long) this->lf_stat.st_size,
+                 (long long) this->lf_stat.st_mtime,
                  filename.c_str());
 
         this->lf_valid_filename = true;


### PR DESCRIPTION
Resolves a crash on startup on FreeBSD/i386 - st_size is 8 bytes, treating it as an int without casting segfaults in log_msg()'s vsnprintf() call.

Cast to long long and fix the format string to match to avoid truncation.  For completeness do the same with st_mtime.