### PR TITLE
add config option to use default fg/bg colors

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -151,6 +151,9 @@ The following options are available:
   in strftime(3).
 * /ui/dim-text - Reduce the brightness of text.  This setting can be useful
   when running in an xterm where the white color is very bright.
+* /ui/default-colors - Use default terminal background and foreground colors
+  instead of black and white for all text coloring.  This setting can be useful
+  when transparent background or alternate color theme terminal is used.
 
 .. note:: The following commands can be disabled by setting the ``LNAVSECURE``
    environment variable before executing the **lnav** binary:

--- a/src/lnav_config.cc
+++ b/src/lnav_config.cc
@@ -305,6 +305,10 @@ static struct json_path_handler ui_handlers[] = {
             .with_synopsis("<bool>")
             .with_description("Reduce the brightness of text (useful for xterms)")
             .for_field(&nullobj<_lnav_config>()->lc_ui_dim_text),
+        json_path_handler("default-colors")
+            .with_synopsis("<bool>")
+            .with_description("Use default terminal fg/bg colors")
+            .for_field(&nullobj<_lnav_config>()->lc_ui_default_colors),
         json_path_handler("keymap")
             .with_synopsis("<name>")
             .with_description("The name of the keymap to use")

--- a/src/lnav_config.hh
+++ b/src/lnav_config.hh
@@ -96,6 +96,7 @@ struct key_map {
 struct _lnav_config {
     std::string lc_ui_clock_format;
     bool lc_ui_dim_text;
+    bool lc_ui_default_colors;
     std::string lc_ui_keymap;
     std::unordered_map<std::string, key_map> lc_ui_keymaps;
     std::map<std::string, std::string> lc_ui_key_overrides;

--- a/src/view_curses.cc
+++ b/src/view_curses.cc
@@ -462,26 +462,33 @@ void view_colors::init(void)
 
         start_color();
 
-        /* use_default_colors(); */
+        use_default_colors();
         for (int fg = 0; fg < 8; fg++) {
             for (int bg = 0; bg < 8; bg++) {
                 if (fg == 0 && bg == 0)
                     continue;
-                init_pair(ansi_color_pair_index(fg, bg),
-                          ansi_colors_to_curses[fg],
-                          ansi_colors_to_curses[bg]);
+                if (lnav_config.lc_ui_default_colors) {
+                    init_pair(ansi_color_pair_index(fg, bg),
+                              (fg == COLOR_WHITE ? -1 : ansi_colors_to_curses[fg]),
+                              (bg == COLOR_BLACK ? -1 : ansi_colors_to_curses[bg]));
+                } else {
+                    init_pair(ansi_color_pair_index(fg, bg),
+                              ansi_colors_to_curses[fg],
+                              ansi_colors_to_curses[bg]);
+                }
             }
         }
 
         if (COLORS == 256) {
             int color_pair_base = VC_ANSI_END;
+            int bg = (lnav_config.lc_ui_default_colors ? -1 : COLOR_BLACK);
 
             for (int z = 0; z < 6; z++) {
                 for (int x = 1; x < 6; x += 2) {
                     for (int y = 1; y < 6; y += 2) {
                         int fg = 16 + x + (y * 6) + (z * 6 * 6);
 
-                        init_pair(color_pair_base, fg, COLOR_BLACK);
+                        init_pair(color_pair_base, fg, bg);
                         color_pair_base += 1;
                     }
                 }


### PR DESCRIPTION
This is to address #270.  Based off @Ass-Pirate's [comment](https://github.com/tstack/lnav/issues/270#issuecomment-195779692) with further attempt to not break other color pairs such as status lines.

To enable:
```
:config /ui/default-colors true
:save-config
```
Restart lnav