### PR TITLE
Fix lnav builds on OpenBSD

### DIFF
--- a/src/command_executor.cc
+++ b/src/command_executor.cc
@@ -29,8 +29,6 @@
 
 #include "config.h"
 
-#include <wordexp.h>
-
 #include <vector>
 
 #include "json_ptr.hh"

--- a/src/grep_proc.cc
+++ b/src/grep_proc.cc
@@ -159,9 +159,9 @@ void grep_proc::child_loop(void)
     char   outbuf[BUFSIZ * 2];
     string line_value;
 
-    FILE *std_out = fdopen(STDOUT_FILENO, "w");
+    *stdout = *(fdopen(STDOUT_FILENO, "w"));
     /* Make sure buffering is on, not sure of the state in the parent. */
-    if (setvbuf(std_out, outbuf, _IOFBF, BUFSIZ * 2) < 0) {
+    if (setvbuf(stdout, outbuf, _IOFBF, BUFSIZ * 2) < 0) {
         perror("setvbuf");
     }
     line_value.reserve(BUFSIZ * 2);
@@ -189,16 +189,16 @@ void grep_proc::child_loop(void)
                     pcre_context::capture_t *m;
 
                     if (pi.pi_offset == 0) {
-                        fprintf(std_out, "%d\n", line);
+                        fprintf(stdout, "%d\n", line);
                     }
                     m = pc.all();
-                    fprintf(std_out, "[%d:%d]\n", m->c_begin, m->c_end);
+                    fprintf(stdout, "[%d:%d]\n", m->c_begin, m->c_end);
                     for (pc_iter = pc.begin(); pc_iter != pc.end();
                          pc_iter++) {
                         if (!pc_iter->is_valid()) {
                             continue;
                         }
-                        fprintf(std_out,
+                        fprintf(stdout,
                                 "(%d:%d)",
                                 pc_iter->c_begin,
                                 pc_iter->c_end);
@@ -210,11 +210,11 @@ void grep_proc::child_loop(void)
                             fwrite(pi.get_substr_start(pc_iter),
                                    1,
                                    pc_iter->length(),
-                                   std_out);
+                                   stdout);
                         }
-                        fputc('\n', std_out);
+                        fputc('\n', stdout);
                     }
-                    fprintf(std_out, "/\n");
+                    fprintf(stdout, "/\n");
                 }
             }
 
@@ -228,7 +228,7 @@ void grep_proc::child_loop(void)
             // When scanning to the end of the source, we need to return the
             // highest line that was seen so that the next request that
             // continues from the end works properly.
-            fprintf(std_out, "h%d\n", line - 1);
+            fprintf(stdout, "h%d\n", line - 1);
         }
         this->child_term();
     }

--- a/src/grep_proc.cc
+++ b/src/grep_proc.cc
@@ -159,9 +159,9 @@ void grep_proc::child_loop(void)
     char   outbuf[BUFSIZ * 2];
     string line_value;
 
-    stdout = fdopen(STDOUT_FILENO, "w");
+    FILE *std_out = fdopen(STDOUT_FILENO, "w");
     /* Make sure buffering is on, not sure of the state in the parent. */
-    if (setvbuf(stdout, outbuf, _IOFBF, BUFSIZ * 2) < 0) {
+    if (setvbuf(std_out, outbuf, _IOFBF, BUFSIZ * 2) < 0) {
         perror("setvbuf");
     }
     line_value.reserve(BUFSIZ * 2);
@@ -189,16 +189,16 @@ void grep_proc::child_loop(void)
                     pcre_context::capture_t *m;
 
                     if (pi.pi_offset == 0) {
-                        fprintf(stdout, "%d\n", line);
+                        fprintf(std_out, "%d\n", line);
                     }
                     m = pc.all();
-                    fprintf(stdout, "[%d:%d]\n", m->c_begin, m->c_end);
+                    fprintf(std_out, "[%d:%d]\n", m->c_begin, m->c_end);
                     for (pc_iter = pc.begin(); pc_iter != pc.end();
                          pc_iter++) {
                         if (!pc_iter->is_valid()) {
                             continue;
                         }
-                        fprintf(stdout,
+                        fprintf(std_out,
                                 "(%d:%d)",
                                 pc_iter->c_begin,
                                 pc_iter->c_end);
@@ -210,11 +210,11 @@ void grep_proc::child_loop(void)
                             fwrite(pi.get_substr_start(pc_iter),
                                    1,
                                    pc_iter->length(),
-                                   stdout);
+                                   std_out);
                         }
-                        fputc('\n', stdout);
+                        fputc('\n', std_out);
                     }
-                    fprintf(stdout, "/\n");
+                    fprintf(std_out, "/\n");
                 }
             }
 
@@ -228,7 +228,7 @@ void grep_proc::child_loop(void)
             // When scanning to the end of the source, we need to return the
             // highest line that was seen so that the next request that
             // continues from the end works properly.
-            fprintf(stdout, "h%d\n", line - 1);
+            fprintf(std_out, "h%d\n", line - 1);
         }
         this->child_term();
     }

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -59,7 +59,7 @@
 
 #include <readline/readline.h>
 
-#if defined(__OpenBSD__) && defined(__OpenBSD__) && \
+#if defined(__OpenBSD__) && defined(__clang__) && \
     !defined(_WCHAR_H_CPLUSPLUS_98_CONFORMANCE_)
 #define _WCHAR_H_CPLUSPLUS_98_CONFORMANCE_
 #endif

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -60,7 +60,9 @@
 #include <readline/readline.h>
 
 #ifdef __clang__
-#define _WCHAR_H_CPLUSPLUS_98_CONFORMANCE_ 1
+#ifndef _WCHAR_H_CPLUSPLUS_98_CONFORMANCE_
+#define _WCHAR_H_CPLUSPLUS_98_CONFORMANCE_
+#endif
 #endif
 #include <map>
 #include <set>

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -59,7 +59,9 @@
 
 #include <readline/readline.h>
 
+#ifdef __clang__
 #define _WCHAR_H_CPLUSPLUS_98_CONFORMANCE_ 1
+#endif
 #include <map>
 #include <set>
 #include <stack>

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -59,6 +59,7 @@
 
 #include <readline/readline.h>
 
+#define _WCHAR_H_CPLUSPLUS_98_CONFORMANCE_ 1
 #include <map>
 #include <set>
 #include <stack>
@@ -2079,6 +2080,7 @@ static void looper(void)
         sig_atomic_t overlay_counter = 0;
         int lpc;
 
+	rl_completer_word_break_characters = (char *)" \t\n"; /* XXX */
         command_context.set_highlighter(readline_command_highlighter);
         search_context
                 .set_append_character(0)
@@ -2086,7 +2088,7 @@ static void looper(void)
         sql_context
                 .set_highlighter(readline_sqlite_highlighter)
                 .set_quote_chars("\"")
-                .with_readline_var(&rl_completer_word_break_characters,
+                .with_readline_var((char **)&rl_completer_word_break_characters,
                                    " \t\n(),");
         exec_context.set_highlighter(readline_shlex_highlighter);
 

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -2082,7 +2082,6 @@ static void looper(void)
         sig_atomic_t overlay_counter = 0;
         int lpc;
 
-	rl_completer_word_break_characters = (char *)" \t\n"; /* XXX */
         command_context.set_highlighter(readline_command_highlighter);
         search_context
                 .set_append_character(0)

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -59,10 +59,9 @@
 
 #include <readline/readline.h>
 
-#ifdef __clang__
-#ifndef _WCHAR_H_CPLUSPLUS_98_CONFORMANCE_
+#if defined(__OpenBSD__) && defined(__OpenBSD__) && \
+    !defined(_WCHAR_H_CPLUSPLUS_98_CONFORMANCE_)
 #define _WCHAR_H_CPLUSPLUS_98_CONFORMANCE_
-#endif
 #endif
 #include <map>
 #include <set>

--- a/src/lnav_util.cc
+++ b/src/lnav_util.cc
@@ -36,7 +36,6 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <ctype.h>
-#include <wordexp.h>
 
 #include <fstream>
 
@@ -698,36 +697,6 @@ bool read_file(const char *filename, string &out)
     }
 
     return false;
-}
-
-bool wordexperr(int rc, string &msg)
-{
-    switch (rc) {
-        case WRDE_BADCHAR:
-            msg = "error: invalid filename character";
-            return false;
-
-        case WRDE_CMDSUB:
-            msg = "error: command substitution is not allowed";
-            return false;
-
-        case WRDE_BADVAL:
-            msg = "error: unknown environment variable in file name";
-            return false;
-
-        case WRDE_NOSPACE:
-            msg = "error: out of memory";
-            return false;
-
-        case WRDE_SYNTAX:
-            msg = "error: invalid syntax";
-            return false;
-
-        default:
-            break;
-    }
-
-    return true;
 }
 
 size_t abbreviate_str(char *str, size_t len, size_t max_len)

--- a/src/lnav_util.hh
+++ b/src/lnav_util.hh
@@ -436,8 +436,6 @@ inline bool pollfd_ready(const std::vector<struct pollfd> &pollfds, int fd, shor
     return false;
 };
 
-bool wordexperr(int rc, std::string &msg);
-
 inline void rusagesub(const struct rusage &left, const struct rusage &right, struct rusage &diff_out)
 {
     timersub(&left.ru_utime, &right.ru_utime, &diff_out.ru_utime);

--- a/src/readline_callbacks.cc
+++ b/src/readline_callbacks.cc
@@ -29,8 +29,6 @@
 
 #include "config.h"
 
-#include <wordexp.h>
-
 #include "lnav.hh"
 #include "lnav_util.hh"
 #include "sysclip.hh"


### PR DESCRIPTION
* Remove all the wordexp related unused headers and code.
* On OpenBSD (maybe other BSDs too) stdout is defined as a macro that expands to
   `&__sF[1]` and not `FILE *`. As a result an expression like `stdout = fdopen(...)`
   becomes invalid, since the lvalue is not assignable. So instead of assigning a pointer,
   change the value pointed to by `stdout` instead, which seems to work on OpenBSD
   and at least on macOS. This might barf if the value pointed to by stdout is in the `readonly`
   section but haven't found that to be the case so far.
* defining `_WCHAR_H_CPLUSPLUS_98_CONFORMANCE_` seems to fix the const
  correctness related redefinitions between `wchar.h` imported from
  the system libc and the one imported by clang++ STL. Making sure that this only kicks
  in when compiling with Clang and on OpenBSD.