### PR TITLE
linebuffer: Ensure get_range returns in-range data

### DIFF
--- a/src/line_buffer.hh
+++ b/src/line_buffer.hh
@@ -231,6 +231,9 @@ private:
 
         require(buffer_offset >= 0);
 
+        // XXX: require(this->lb_buffer_size >= buffer_offset);
+        buffer_offset = std::min(buffer_offset, this->lb_buffer_size);
+
         retval    = &this->lb_buffer[buffer_offset];
         avail_out = this->lb_buffer_size - buffer_offset;
 


### PR DESCRIPTION
In get_range if the requested offset is not in the cache, we could return
a very large integer in avail_out.  This is caused by converting a
negative value into an unsigned (size_t).  It seems like we should
`require` this value to be in-range, but it seems like several callers
already call us without their offset already in range.  They seem to
accept a zero-length to mean we don't have their data, though.

Ensure that the returned avail_out parameter doesn't try to go negative.
If the requested offset is not cached, return a zero-length width so the
caller doesn't think we have anything useful for them.

---

I noticed this problem when lnav was crashing on exit in read_line when I was viewing a large .gz compressed file.  I didn't figure out the logic that caused read_line to think this was ok, but I noticed that we don't check the return value from fill_range in that code, so maybe the mistake is there.  Or maybe fill_range does the wrong thing with compressed file requests in some cases.

My concern is that there is another bug lurking in here somewhere.  It might be useful to instrument some expectations and try to catch unexpected values still.