### PR TITLE
string2level uses wrong string length

### DIFF
--- a/src/log_format.cc
+++ b/src/log_format.cc
@@ -108,7 +108,8 @@ logline::level_t logline::string2level(const char *levelstr, ssize_t len, bool e
     pcre_context_static<10> pc;
 
     if (LEVEL_RE.match(pc, pi)) {
-        retval = abbrev2level(pi.get_substr_start(pc.begin()), len);
+        auto iter = pc.begin();
+        retval = abbrev2level(pi.get_substr_start(iter), pi.get_substr_len(iter));
     }
 
     return retval;

--- a/src/pcrepp.hh
+++ b/src/pcrepp.hh
@@ -227,6 +227,11 @@ public:
         return &this->pi_string[iter->c_begin];
     };
 
+    size_t get_substr_len(pcre_context::const_iterator iter) const
+    {
+        return iter->length();
+    };
+
     std::string get_substr(pcre_context::const_iterator iter) const
     {
         if (iter->c_begin == -1) {


### PR DESCRIPTION
It should pass only the matched length, not the original string length.
Caught by -fsanitize=address while trying to parse "some string (DEBUG)"

Probably deserves a unit test.  I started one, but felt a little directionless.  Might try again later.