### PR TITLE
Fix some build issues with musl as libc

### DIFF
--- a/src/grep_proc.cc
+++ b/src/grep_proc.cc
@@ -159,7 +159,6 @@ void grep_proc::child_loop(void)
     char   outbuf[BUFSIZ * 2];
     string line_value;
 
-    *stdout = *(fdopen(STDOUT_FILENO, "w"));
     /* Make sure buffering is on, not sure of the state in the parent. */
     if (setvbuf(stdout, outbuf, _IOFBF, BUFSIZ * 2) < 0) {
         perror("setvbuf");

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -1886,7 +1886,7 @@ static void handle_key(int ch) {
     }
 
     switch (ch) {
-    case CEOF:
+    case CTRL('d'):
     case KEY_RESIZE:
         break;
     default:
@@ -2416,7 +2416,7 @@ static void looper(void)
                         }
 
                         switch (ch) {
-                        case CEOF:
+                        case CTRL('d'):
                         case KEY_RESIZE:
                             break;
 


### PR DESCRIPTION
I had some issues building 0.8.3 on gentoo with musl as libc (amd64).

First of all, CEOF is not defined. I'm guessing, that it is the same as EOF, but I couldn't figure out, where the CEOF comes from or what it should be.

Secondly FILE is an incomplete type on musl and in turn it can't be dereferenced. This is allowed by the standard and it is undefined/unspecified/implementation defined/whatever behavior to dereference a FILE*. The code in question looks a bit funky. I don't know, why the file descriptor for STDOUT is opened at this place and why you would reassign stdout. The may be some intention behind that, but from looking at the history, I couldn't figure it out.

You may want to check both of those changes, as I am not confident, that this won't break anything, as I don't know, why the code was written this way. With those changes, I can compile the code on glibc as well as musl and lnav still seems to work, although I didn't do any extensive testing.