### PR TITLE
Added snap package support

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,38 @@
+name: lnav
+version: '0.8.3'
+summary: Log file navigator
+description: |
+  The log file navigator, lnav, is an enhanced log file viewer 
+  that takes advantage of any semantic information 
+  that can be gleaned from the files being viewed.
+
+grade: stable
+confinement: strict
+
+apps:
+  lnav-simosx:
+    command: lnav
+    plugs: 
+      - home            # optional, allows to read log files from home directory
+      - log-observe     # required, provide access to system logs in /var/log
+      - network         # required, lnav uses sendto() with UNIX domain socket 
+
+parts:
+  lnav:
+    plugin: autotools
+    source: https://github.com/tstack/lnav.git
+    source-tag: v0.8.3
+    build-packages: 
+      - build-essential
+      - libpcre3-dev
+      - libsqlite3-dev
+      - libncursesw5-dev
+      - libreadline-dev
+      - zlib1g-dev
+      - libbz2-dev
+      - libgpm-dev
+    stage-packages: 
+      - zlib1g
+      - libncursesw5
+      - libpcre3
+      - libgpm2


### PR DESCRIPTION
*Snap packages* is one of the new package format that runs on many Linux distributions and also developer boards like the Raspberry Pi. They provide confinement of the snapped package and work especially well with Ubuntu Core. Confinement is good, because if somehow the application is compromised from malformed logs, it will not affect the rest of the system.

This PR adds a file `snapcraft.yaml` at the root of the repository.

To create the snap package yourselves: 

1. Install snap support, if your Linux distro does not have it already (https://docs.snapcraft.io/core/install)
2. Install the *snapcraft* snap creation tool, with `sudo snap install snapcraft --classic`
3. In the `lnav` directory, run `snapcraft`. This will generate the snap package *lnav_0.8.3_amd64.snap*. (To clean up, run `snapcraft --clean`)
4. You can then publish this snap to the Ubuntu Snap Store. See some instructions at https://tutorials.ubuntu.com/tutorial/create-your-first-snap

I went ahead and published an unofficial snap `lnav-simosx`, and you can test it now as follows:

    sudo snap install lnav-simosx      # available in `amd64`, `i386`, `armhf` and `arm64`

Then, run the special command that gives access to the system log files. When you eventually make the official snap, you do not have to run the following command.

    sudo snap connect lnav-simosx:log-observe core:log-observe

Then, you can run lnav as:
`lnav-simosx.lnav`
It looks a bit awkward with the repetition, but this happens because it's an unofficial snap (note the -`simosx`). The PR has the proper name so that you can run straight away as `lnav`.

A note on confinement: The snap has `strict` confinement, which means that it is very much confined and can only access 

1. the home directory and any mounted partitions (to potentially read log files)
2. can make connections to the Internet (the lnav code uses `sendto()` for Unix sockets)
3. can access the system logs.