### PR TITLE
Fix openstack_log debug level

### DIFF
--- a/src/default-log-formats.json
+++ b/src/default-log-formats.json
@@ -1055,7 +1055,7 @@
             "info" : "INFO",
             "warning" : "WARNING",
 	    "trace" : "TRACE",
-	    "debug" : "AUDIT"
+	    "debug" : "DEBUG"
         },
         "value" : {
             "tid" : {


### PR DESCRIPTION
So ":set-min-log-level info" gets rid of lines with DEBUG.