### PR TITLE
Fix typo in manpage

### DIFF
--- a/lnav.1
+++ b/lnav.1
@@ -92,7 +92,7 @@ directory will be loaded.
 To load and follow the syslog file:
 .PP
 .Vb 1
-\&    lnav \-s
+\&    lnav
 .Ve
 .PP
 To load all of the files in /var/log:


### PR DESCRIPTION
That -s parameter doesn't seem to be used anymore. It was even removed from the _usage_ examples in **lnav.cc**.