### PR TITLE
Add ./autogen.sh command to build lnav

### DIFF
--- a/README
+++ b/README
@@ -34,6 +34,7 @@ INSTALLATION
 
 Lnav follows the usual GNU style for configuring and installing software:
 
+  $ ./autogen.sh
   $ ./configure
   $ make
   $ sudo make install


### PR DESCRIPTION
`./configure` does not exist in the repository. Users need to run `./autogen.sh` in order to generate it.

This PR adds this step in the README file.