### PR TITLE
Add thread id for multithreaded Apache error log

### DIFF
--- a/src/default-log-formats.json
+++ b/src/default-log-formats.json
@@ -546,7 +546,7 @@
                 "pattern" : "^(?<level>\\w) \\[(?<timestamp>[^\\]]+)\\] (?<body>.*)"
             },
             "apache" : {
-                "pattern" : "^\\[(?<timestamp>[^\\]]+)\\] \\[(?:(?<module>[^:]+):)?(?<level>\\w+)\\](?: \\[pid (?<pid>\\d+)\\])?(?: \\[client (?<c_ip>[\\w\\.:\\-]+):(?<c_port>\\d+)\\])? (?<body>.*)"
+                "pattern" : "^\\[(?<timestamp>[^\\]]+)\\] \\[(?:(?<module>[^:]+):)?(?<level>\\w+)\\](?: \\[pid (?<pid>\\d+)(:tid (?<tid>\\d+))?\\])?(?: \\[client (?<c_ip>[\\w\\.:\\-]+):(?<c_port>\\d+)\\])? (?<body>.*)"
             }
         },
         "level-field": "level",
@@ -558,6 +558,11 @@
             "pid": {
                 "kind" : "integer",
                 "identifier" : true
+            },
+            "tid": {
+                "kind" : "integer",
+                "identifier" : true,
+                "description" : "The thread id"
             },
             "c_ip" : {
                 "kind" : "string",
@@ -586,6 +591,14 @@
             {
                 "line": "[Thu Jan 17 02:42:49 2013] [notice] Digest: generating secret for digest authentication ...",
                 "level" : "notice"
+            },
+            {
+                "line" : "[Thu May 12 08:28:57.652118 2011] [core:error] [pid 8777:tid 4326490112] [client ::1:58619] File does not exist: /usr/local/apache2/htdocs/favicon.ico",
+                "level" : "error"
+            },
+            {
+                "line" : "[Thu Jan 02 22:23:07.368853 2020] [http:info] [pid 4784:tid 139701043291904] [client 66.220.149.10:45948] AH01593: chunked Transfer-Encoding forbidden: /",
+                "level" : "info"
             }
         ]
     },


### PR DESCRIPTION
Default `ErrorLogFormat` from Apache add a `tid` info (Thread ID) for some multithreaded configuration.

https://httpd.apache.org/docs/2.4/en/mod/core.html (see "default format for threaded MPMs" example)

This PR provides `tid` parsing if available.
