### PR TITLE
Prevent deletion of checked in files.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,14 @@ Jan Chren
 Geoff Crompton
 Medina Maza
 Phil Hord
+Tristan Ramseyer
+Aurélien Rouëné
+Emiliano Bonassi
+Darragh O'Reilly
+Stéphane Blondon
+Miguel Terron
+Enguerrand de Rochefort
+Nicolas Werner
+Matt Hayden
+Simos Xenitellis
+Finnegan Stack


### PR DESCRIPTION
Prevent checked in files from being deleted during `make distclean`.