### PR TITLE
Minor changes to quell some compiler warnings and other miscellaneous changes.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,7 +13,7 @@ Christopher Meng
 Salvatore Bonaccorso
 Henrietta Stack
 Pablo Iranzo Gómez
-androm3da (https://github.com/androm3da)
+Brian Cain
 Paul Wayper
 Adam Spiers
 Kevin Pham

--- a/src/base/lnav_log.cc
+++ b/src/base/lnav_log.cc
@@ -323,8 +323,11 @@ void log_msg_extra_complete()
 static void sigabrt(int sig)
 {
     char crash_path[1024], latest_crash_path[1024];
-    int fd, frame_count;
+    int fd;
+#ifdef HAVE_EXECINFO_H
+    int frame_count;
     void *frames[128];
+#endif
     struct tm localtm;
     time_t curr_time;
 

--- a/src/formats/vmw_log.json
+++ b/src/formats/vmw_log.json
@@ -26,7 +26,7 @@
                 "pattern": "^(?<timestamp>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?(?:Z|[-+]\\d{2}:\\d{2})) (?<prc>[^:]+):\\s+(?<tid>\\w+):\\s+(?<comp>[^:]+):(?<line>\\d+)?\\s+(?<level>\\w+):?\\s+(?<body>.*)(?:\\n(?:.|\\n)*)?$"
             },
             "vum-log4cpp": {
-                "pattern": "^\\[(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}:\\d{3}) '(?<category>[^']*)' (?<tid>\\d+) (?<level>EMERG|FATAL|ALERT|CRIT|ERROR|WARN|NOTICE|INFO|DEBUG|NOTSET)\\]\\s+(\\[(?<file>\\S+), (?<line>\\d+)\\])? (?<body>.*$)"
+                "pattern": "^\\[(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}:\\d{3}) '(?<category>[^']*)' (?<tid>\\d+) (?<level>[a-zA-Z]+)\\]\\s+(\\[(?<file>\\S+), (?<line>\\d+)\\])? (?<body>.*$)"
             }
         },
         "level-field": "level",

--- a/src/formats/vmw_log.json
+++ b/src/formats/vmw_log.json
@@ -26,7 +26,7 @@
                 "pattern": "^(?<timestamp>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?(?:Z|[-+]\\d{2}:\\d{2})) (?<prc>[^:]+):\\s+(?<tid>\\w+):\\s+(?<comp>[^:]+):(?<line>\\d+)?\\s+(?<level>\\w+):?\\s+(?<body>.*)(?:\\n(?:.|\\n)*)?$"
             },
             "vum-log4cpp": {
-                "pattern": "^\\[(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}:\\d{3}) '(?<category>[^']*)' (?<tid>\\d+) (?<level>[a-zA-Z]+)\\]\\s+(\\[(?<file>\\S+), (?<line>\\d+)\\])? (?<body>.*$)"
+                "pattern": "^\\[(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}:\\d{3}) '(?<category>[^']*)' (?<tid>\\d+) (?<level>[a-zA-Z]+)\\]\\s+(?>\\[(?<file>\\S+), (?<line>\\d+)\\])? (?<body>.*$)"
             }
         },
         "level-field": "level",

--- a/src/lnav_config.hh
+++ b/src/lnav_config.hh
@@ -32,8 +32,6 @@
 #ifndef _lnav_config_hh
 #define _lnav_config_hh
 
-#include <sys/queue.h>
-
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
- AUTHORS: Replace username with contributor's actual name.
- lnav_log.cc: Put the variable declaration behind the same macros as their usage.
- lnav_config.hh: Remove the unused sys/queue.h headers.
- vmw_log.json: Optimize the vum-log4cpp regex.