### PR TITLE
[release] Build target for static lnav compiled with musl-libc.

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -21,7 +21,7 @@ PACKAGE_URLS = \
 	https://www.libssh2.org/download/libssh2-1.9.0.tar.gz \
 	https://curl.haxx.se/download/curl-7.72.0.tar.gz
 
-.PHONY: linux freebsd pkger download-pkgs
+.PHONY: linux freebsd pkger download-pkgs musl
 
 %-vm: %
 	cd vagrant-static && vagrant up $<

--- a/release/vagrant-static/Vagrantfile
+++ b/release/vagrant-static/Vagrantfile
@@ -29,6 +29,13 @@ Vagrant.configure(2) do |config|
       freebsd.vm.base_mac = "080027D14C66"
   end
 
+  config.vm.define :musl do |musl|
+      musl.vm.network "private_network", :type => 'dhcp'
+      musl.vm.provision "shell", path:"musl-pkg.sh"
+      musl.vm.provision "shell", path:"provision.sh"
+      musl.vm.box = "generic/alpine312"
+  end
+
   config.vm.define :linux do |linux|
       linux.vm.network :private_network, ip: "10.11.12.14"
       linux.vm.provision "shell", path:"pkg.sh"

--- a/release/vagrant-static/musl-pkg.sh
+++ b/release/vagrant-static/musl-pkg.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+sudo apk update && sudo apk upgrade
+sudo apk add build-base m4 git zip perl ncurses autoconf automake libtool linux-headers
+wget 'https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=misc/sys/queue.h;hb=HEAD' -O queue.h
+sudo mv queue.h /usr/include/sys/

--- a/release/vagrant-static/provision.sh
+++ b/release/vagrant-static/provision.sh
@@ -76,32 +76,32 @@ OS=$(uname -s)
  bunzip2 ncurses-5.9-20141206-patch.sh.bz2 &&
  bash ./ncurses-5.9-20141206-patch.sh)
 
+(cd ncurses-5.9 && \
+ ./configure --prefix=${FAKE_ROOT} \
+     --enable-ext-mouse \
+     --enable-sigwinch \
+     --with-default-terminfo-dir=/usr/share/terminfo \
+     --enable-ext-colors \
+     --enable-widec \
+     --enable-termcap \
+     --with-fallbacks=$NCURSES_FALLBACKS \
+     && \
+ make && make install)
+
+(cd pcre-* && \
+ ./configure --prefix=${FAKE_ROOT} \
+     --enable-jit \
+     --enable-utf \
+     && \
+ make && make install)
+
 if test x"${OS}" != x"FreeBSD"; then
-    (cd ncurses-5.9 && \
-     ./configure --prefix=${FAKE_ROOT} \
-         --enable-ext-mouse \
-         --enable-sigwinch \
-         --with-default-terminfo-dir=/usr/share/terminfo \
-         --enable-ext-colors \
-         --enable-widec \
-         --enable-termcap \
-         --with-fallbacks=$NCURSES_FALLBACKS \
-         && \
-     make && make install)
-
-    (cd pcre-* && \
-     ./configure --prefix=${FAKE_ROOT} \
-         --enable-jit \
-         --enable-utf \
-         && \
-     make && make install)
-
     (cd zlib-1.2.11 && ./configure --prefix=${FAKE_ROOT} && make && make install)
 
     (cd libssh2-* &&
      ./configure --prefix=${FAKE_ROOT} \
-         --with-libssl-prefix=/home/vagrant/fake.root \
-         --with-libz-prefix=/home/vagrant/fake.root \
+         --with-libssl-prefix=${FAKE_ROOT} \
+         --with-libz-prefix=${FAKE_ROOT} \
          "CPPFLAGS=-I${FAKE_ROOT}/include" \
          "LDFLAGS=-ldl -L${FAKE_ROOT}/lib" &&
      make &&
@@ -116,32 +116,13 @@ if test x"${OS}" != x"FreeBSD"; then
      make &&
      make install)
 else
-    (cd ncurses-5.9 && \
-     ./configure --prefix=${FAKE_ROOT} \
-         --enable-ext-mouse \
-         --enable-sigwinch \
-         --with-default-terminfo-dir=/usr/share/terminfo \
-         --enable-ext-colors \
-         --enable-widec \
-         --enable-termcap \
-         --with-fallbacks=$NCURSES_FALLBACKS \
-         && \
-     make && make install)
-
-    (cd pcre-* && \
-     ./configure --prefix=${FAKE_ROOT} \
-         --enable-jit \
-         --enable-utf \
-         && \
-     make && make install)
-
     (cd zlib-1.2.11 && ./configure --prefix=${FAKE_ROOT} "CFLAGS=-fPIC" \
         && make && make install)
 
     (cd libssh2-* &&
      ./configure --prefix=${FAKE_ROOT} \
-         --with-libssl-prefix=/home/vagrant/fake.root \
-         --with-libz-prefix=/home/vagrant/fake.root \
+         --with-libssl-prefix=${FAKE_ROOT} \
+         --with-libz-prefix=${FAKE_ROOT} \
          &&
      make &&
      make install)


### PR DESCRIPTION
`musl-package` release target compiles a completely static `lnav` binary compiled with
musl-libc.