### PR TITLE
[freebsd] Remove basename from log_msg.cc and update the FreeBSD image in the VagrantFile.

### DIFF
--- a/release/vagrant-static/Vagrantfile
+++ b/release/vagrant-static/Vagrantfile
@@ -22,11 +22,12 @@ Vagrant.configure(2) do |config|
       freebsd.vm.network "private_network", :type => 'dhcp'
       freebsd.vm.provision "shell", path:"pkg.sh"
       freebsd.vm.provision "shell", path:"provision.sh"
-      freebsd.vm.box = "freebsd/FreeBSD-11.2-RELEASE"
-      freebsd.vm.box_version = "2018.06.22"
+      freebsd.vm.box = "freebsd/FreeBSD-12.1-RELEASE"
+      freebsd.vm.box_version = "2019.11.01"
       freebsd.vm.synced_folder ".", "/vagrant", type: "nfs"
       freebsd.ssh.shell = "sh"
       freebsd.vm.base_mac = "080027D14C66"
+      freebsd.vm.boot_timeout = 1200
   end
 
   config.vm.define :musl do |musl|

--- a/src/base/lnav_log.cc
+++ b/src/base/lnav_log.cc
@@ -41,7 +41,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <signal.h>
-#include <libgen.h>
 #include <pthread.h>
 #include <sys/resource.h>
 
@@ -274,7 +273,7 @@ void log_msg(lnav_log_level_t level, const char *src_file, int line_number,
         localtm.tm_sec,
         (int)(curr_time.tv_usec / 1000),
         LEVEL_NAMES[to_underlying(level)],
-        basename((char *)src_file),
+        src_file,
         line_number);
     rc = vsnprintf(&line[prefix_size], MAX_LOG_LINE_SIZE - prefix_size,
         fmt, args);


### PR DESCRIPTION
Posix basename apparently modifies it's arguments and lnav_log.cc calls
basename on static strings.