### PR TITLE
Don't try to read concatenated gzip streams

### DIFF
--- a/src/line_buffer.hh
+++ b/src/line_buffer.hh
@@ -104,7 +104,6 @@ public:
 
         void close();
         void init_stream();
-        void continue_stream();
         void open(int fd);
         int stream_data(void * buf, size_t size);
         void seek(off_t offset);


### PR DESCRIPTION
Don't try to continue reading the next stream of a concatenated
gzip file.  The next stream may be CRC noise or other garbage.

Maybe in the future we should look for a gzip header in the
following bytes of the stream and try to decode from there.
But it's not clear that anyone ever uses this supposed gzip
feature anyway.

Let's just end the stream when we reach EOS. Also, if the
stream fails to init, let's leave it closed instead of throwing
an error no one is likely to catch.  Log the error msg from
zlib if one is provided.