### PR TITLE
Add `tmux` terminfo entries

### DIFF
--- a/release/vagrant-static/provision.sh
+++ b/release/vagrant-static/provision.sh
@@ -39,6 +39,8 @@ rxvt-256color,\
 screen,\
 screen-16color,\
 screen-256color,\
+tmux,\
+tmux-256color,\
 vt100,\
 vt220,\
 xterm,\


### PR DESCRIPTION
Recent terminfo databases contain two entries for tmux sessions,
`tmux` and `tmux-256color`. This change adds these two entries.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>