### PR TITLE
gzip stream continuation

### DIFF
--- a/src/line_buffer.cc
+++ b/src/line_buffer.cc
@@ -215,8 +215,8 @@ int line_buffer::gz_indexed::stream_data(void * buf, size_t size)
                 // Reached end of stream; re-init for a possible subsequent stream
                 continue_stream();
             } else if (err != Z_OK) {
-                log_error(" inflate-error: %d", (int)err);
-                throw error(err);  // FIXME: exception wrapper
+                log_error(" inflate-error: %d  %s", (int)err, this->strm.msg ? this->strm.msg : "");
+                break;
             }
 
             if (this->strm.total_in >= last + SYNCPOINT_SIZE &&

--- a/src/line_buffer.hh
+++ b/src/line_buffer.hh
@@ -104,6 +104,7 @@ public:
 
         void close();
         void init_stream();
+        void continue_stream();
         void open(int fd);
         int stream_data(void * buf, size_t size);
         void seek(off_t offset);


### PR DESCRIPTION
This reverts the previous fix and fixes the earlier crash in a different way (simply by not crashing on unexpected data).  gzip streams need better coddling, and this is enough for them, it seems.

This re-enables multi-part streams. Those are somewhat common.  I found some in my logs that I were being cut off early with my previous change.