### PR TITLE
Change regex for recognizing errors in the syslog format

### DIFF
--- a/src/formats/syslog_log.json
+++ b/src/formats/syslog_log.json
@@ -14,7 +14,7 @@
         },
         "level-field": "body",
         "level": {
-            "error": "(?:(?:(?<![a-zA-Z]))(?:(?i)error(?:s)?)(?:(?![a-zA-Z]))|failed|failure)",
+            "error": "(?:(?:(?<![a-zA-Z]))(?:(?i)err(?:s)?)(?:(?![a-zA-Z]))|failed|failure)",
             "warning": "(?:(?:(?i)warn)|not responding|init: cannot execute)"
         },
         "opid-field": "log_pid",


### PR DESCRIPTION
I have found that `err` is used as an alias to `error`.
Changing the regex to catch `err` would work for both usages.