### PR TITLE
Fix schema reference

### DIFF
--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -49,13 +49,13 @@ analysis.
 
 An **lnav** format file must contain a single JSON object, preferably with a
 :code:`$schema` property that refers to the
-`config-v1.schema <https://lnav.org/schemas/config-v1.schema.json>`_,
+`format-v1.schema <https://lnav.org/schemas/format-v1.schema.json>`_,
 like so:
 
 .. code-block:: json
 
    {
-       "$schema": "https://lnav.org/schemas/config-v1.schema.json"
+       "$schema": "https://lnav.org/schemas/format-v1.schema.json"
    }
 
 Each format to be defined in the file should a separate field in the top-level


### PR DESCRIPTION
The schema should be `format` instead of `config`.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>