### PR TITLE
Add `#include <iterator>` to `string_util.cc`

### DIFF
--- a/src/base/string_util.cc
+++ b/src/base/string_util.cc
@@ -29,6 +29,7 @@
 
 #include "config.h"
 
+#include <iterator>
 #include <regex>
 #include <sstream>
 


### PR DESCRIPTION
Lnav fails to build on the next Fedora version due to the following error:
```
make[3]: Entering directory '/builddir/build/BUILD/lnav-0.10.1/src/base'
g++ -std=c++14 -DHAVE_CONFIG_H -I. -I../../src   -Wall -I../../src/ -I../../src/third-party -I../../src/fmtlib     -I../../src/third-party/doctest-root  -I/usr/local/include -D_ISOC99_SOURCE -D__STDC_LIMIT_MACROS -D_GNU_SOURCE  -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -c -o string_util.o string_util.cc
make[3]: Leaving directory '/builddir/build/BUILD/lnav-0.10.1/src/base'
string_util.cc: In function 'std::string repeat(const std::string&, size_t)':
string_util.cc:199:22: error: 'ostream_iterator' is not a member of 'std'
  199 |     std::fill_n(std::ostream_iterator<std::string>(os), num, input);
      |                      ^~~~~~~~~~~~~~~~
string_util.cc:38:1: note: 'std::ostream_iterator' is defined in header '<iterator>'; did you forget to '#include <iterator>'?
   37 | #include "string_util.hh"
  +++ |+#include <iterator>
   38 |
```

Reason is probably the updated GNU toolchain, more info:
https://fedoraproject.org/wiki/Changes/GNUToolchainF36

This patch fixes the issue.