### PR TITLE
Misalignment in the end of highlighted areas: correction

### DIFF
--- a/src/view_curses.cc
+++ b/src/view_curses.cc
@@ -261,7 +261,7 @@ view_curses::mvwattrline(WINDOW* window,
 
         if (attr_range.lr_end != -1) {
             for (const auto& adj : utf_adjustments) {
-                if (adj.uda_origin < iter->sa_range.lr_end) {
+                if (adj.uda_origin < iter->sa_range.lr_start) {
                     attr_range.lr_end += adj.uda_offset;
                 }
             }


### PR DESCRIPTION
The end of highlighted areas was misaligned in the presence of non-ASCII characters.
This should provide a fix for issue #1033 .
Feel free to ask for corrections or reject the PR should I have missed the target.

From empirical tests it works and looking at #745 to understand the original purpose of the modified code it should make sense, but I could be missing something.