### PR TITLE
Only build ssh keys when needed

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -478,7 +478,7 @@ DISTCLEANFILES = \
 	empty \
 	scripts-empty
 
-all-local: remote/ssh_host_dsa_key remote/ssh_host_rsa_key remote/id_rsa
+test_remote.sh.log: remote/ssh_host_dsa_key remote/ssh_host_rsa_key remote/id_rsa
 
 distclean-local:
 	$(RM_V)rm -rf remote remote-tmp not:a:remote:dir


### PR DESCRIPTION
I believe the test/remote folder only needs to be setup for
test/test_remote.sh. Prior to this commit, it was being built during
make, rather than just during make check. This commit adjusts things so
that the test/remote folder is only generated during make check, and
only when test/test_remote.sh is being executed.

Fixes #1040

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>