### PR TITLE
[view_curses] Fix for fg colour and reverse attribute for separator bars

### DIFF
--- a/src/view_curses.cc
+++ b/src/view_curses.cc
@@ -324,6 +324,7 @@ view_curses::mvwattrline(WINDOW* window,
 
             if (iter->sa_type == &VC_GRAPHIC) {
                 graphic = iter->sa_value.get<int64_t>();
+                attrs = text_attrs{};
             } else if (iter->sa_type == &VC_STYLE) {
                 attrs = iter->sa_value.get<text_attrs>();
             } else if (iter->sa_type == &SA_LEVEL) {


### PR DESCRIPTION
Hello @tstack .
Elements of type VC_GRAPHIC used as column separators, when used along with background coloured bars to express numeric column values or in the presence of highlighted areas, maintain alternate-line reversing of colours when inside the bar range and take the foreground color/reversing state of the last coloured bar on the line even though when not placed within the coloured range of characters.

This commit fixes this.
Below some before/after pictures.

Before:
![Screenshot from 2022-09-04 18-46-12](https://user-images.githubusercontent.com/69568/188324473-6ca8057e-9478-46d4-9c1a-ae2800030e70.png)
![Screenshot from 2022-09-04 18-45-56](https://user-images.githubusercontent.com/69568/188324476-21a6e162-5ba1-456e-90cc-01e566a7fa4d.png)

After:
![Screenshot from 2022-09-04 18-48-53](https://user-images.githubusercontent.com/69568/188324493-01aea707-7776-4f9d-8765-3734b3a837ea.png)
![Screenshot from 2022-09-04 18-48-25](https://user-images.githubusercontent.com/69568/188324496-721fb8bd-c515-44e2-b841-72dd74c4944a.png)


Note: I've only tried this with the log and db views, so it would help if it could be tested with other views to be extra sure.