### PR TITLE
Modification to avoid color conflicts for colored bars

### DIFF
--- a/src/command_executor.cc
+++ b/src/command_executor.cc
@@ -28,6 +28,7 @@
  */
 
 #include <vector>
+#include <algorithm>
 
 #include "command_executor.hh"
 
@@ -926,6 +927,31 @@ sql_callback(exec_context& ec, sqlite3_stmt* stmt)
             dls.push_header(colname, type, graphable);
             if (graphable) {
                 auto attrs = vc.attrs_for_ident(colname);
+                dls.dls_headers[lpc].hm_colorstr = colname;
+                for (
+                    std::string suf = " ";
+                    std::any_of(
+                        dls.fg_colors_vec.cend() - ( std::min((int)dls.fg_colors_vec.size(), (int) (view_colors::HI_COLOR_COUNT - 1))),
+                        dls.fg_colors_vec.cend(),
+                        [attrs](auto el) {return el == attrs.ta_fg_color;}
+                        ) ||
+                    std::any_of(
+                        dls.bg_colors_vec.cend() - ( std::min((int)dls.bg_colors_vec.size(), (int) (view_colors::HI_COLOR_COUNT - 1))),
+                        dls.bg_colors_vec.cend(),
+                        [attrs](auto el) {return el == attrs.ta_bg_color;}
+                    );
+                    suf += " "
+                ) {
+                    attrs = vc.attrs_for_ident(colname + suf);
+                    dls.dls_headers[lpc].hm_colorstr = colname + suf;
+                }
+
+                if (attrs.ta_fg_color) {
+                    dls.fg_colors_vec.emplace_back(attrs.ta_fg_color);
+                }
+                if (attrs.ta_bg_color) {
+                    dls.bg_colors_vec.emplace_back(attrs.ta_bg_color);
+                }
                 chart.with_attrs_for_ident(colname, attrs);
             }
         }

--- a/src/db_sub_source.cc
+++ b/src/db_sub_source.cc
@@ -260,6 +260,8 @@ db_label_source::clear()
     this->dls_time_column.clear();
     this->dls_cell_width.clear();
     this->dls_allocator = std::make_unique<ArenaAlloc::Alloc<char>>(64 * 1024);
+    this->fg_colors_vec.clear();
+    this->bg_colors_vec.clear();
 }
 
 nonstd::optional<size_t>
@@ -436,7 +438,7 @@ db_overlay_source::list_value_for_overlay(const listview_curses& lv,
 
             text_attrs attrs;
             if (this->dos_labels->dls_headers[lpc].hm_graphable) {
-                attrs = vc.attrs_for_ident(dls->dls_headers[lpc].hm_name)
+                attrs = vc.attrs_for_ident(dls->dls_headers[lpc].hm_colorstr)
                     | text_attrs{A_REVERSE};
             } else {
                 attrs.ta_attrs = A_UNDERLINE;

--- a/src/db_sub_source.hh
+++ b/src/db_sub_source.hh
@@ -99,7 +99,7 @@ public:
     }
 
     struct header_meta {
-        explicit header_meta(std::string name) : hm_name(std::move(name)) {}
+        explicit header_meta(std::string name) : hm_name(std::move(name)), hm_colorstr(std::move(name)) {}
 
         bool operator==(const std::string& name) const
         {
@@ -107,6 +107,7 @@ public:
         }
 
         std::string hm_name;
+        std::string hm_colorstr;
         int hm_column_type{SQLITE3_TEXT};
         unsigned int hm_sub_type{0};
         bool hm_graphable{false};
@@ -114,6 +115,8 @@ public:
     };
 
     stacked_bar_chart<std::string> dls_chart;
+    std::vector<nonstd::optional<short>> fg_colors_vec;
+    std::vector<nonstd::optional<short>> bg_colors_vec;
     std::vector<header_meta> dls_headers;
     std::vector<std::vector<const char*>> dls_rows;
     std::vector<struct timeval> dls_time_column;


### PR DESCRIPTION
Fix to avoid reusing the same color for numeric columns when graphed in the SQL view.
A problem with columns graphed from JSON fields remains.
Addresses #1047 .

Again @tstack , since I am not really a C++ developer, any advice/correction is appreciated.