### PR TITLE
[pcre2] don't add PRCE2_HOME to the search path if it is empty

### DIFF
--- a/m4/ax_check_pcre2.m4
+++ b/m4/ax_check_pcre2.m4
@@ -140,8 +140,10 @@ then
     # If both library and header were found, action-if-found
     #
     m4_ifblank([$2],[
-                CPPFLAGS="$CPPFLAGS -I${PCRE2_HOME}/include"
-                LDFLAGS="$LDFLAGS -L${PCRE2_HOME}/lib"
+                if test -n "${PCRE2_HOME}"; then
+                  CPPFLAGS="$CPPFLAGS -I${PCRE2_HOME}/include"
+                  LDFLAGS="$LDFLAGS -L${PCRE2_HOME}/lib"
+                fi
                 LIBS="-lpcre2-8 $LIBS"
                 AC_DEFINE([HAVE_PCRE2], [1],
                           [Define to 1 if you have `PCRE2' library (-lpcre2-$1)])


### PR DESCRIPTION
This used to add -L/lib to LDFLAGS which was not an issue unless you are cross compiling and then it may detect PCRE features based on the host PCRE not the target one.