### PR TITLE
Fix build with GCC 13 (add missing <cstdint> include)

### DIFF
--- a/src/base/lnav_log.hh
+++ b/src/base/lnav_log.hh
@@ -32,6 +32,7 @@
 #ifndef lnav_log_hh
 #define lnav_log_hh
 
+#include <cstdint>
 #include <string>
 
 #include <stdio.h>


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes and so <cstdint> is no longer transitively included.

Explicitly include <cstdint> for uint32_t.

Signed-off-by: Sam James <sam@gentoo.org>