### PR TITLE
RFC: test_sql_str_func.sh: Correct expected output on bad IPv6 address

### DIFF
--- a/test/expected/test_sql_str_func.sh_3855d2cc0ab29171cae8e722f130adec25eae36e.err
+++ b/test/expected/test_sql_str_func.sh_3855d2cc0ab29171cae8e722f130adec25eae36e.err
@@ -1,1 +1,1 @@
-error: sqlite3_exec failed -- lnav-error:{"level":"error","message":{"str":"invalid URL: “https://bad@[fe::”","attrs":[]},"reason":{"str":"Port number was not a decimal number between 0 and 65535","attrs":[]},"snippets":[],"help":{"str":"","attrs":[]}}
+error: sqlite3_exec failed -- lnav-error:{"level":"error","message":{"str":"invalid URL: “https://bad@[fe::”","attrs":[]},"reason":{"str":"Bad IPv6 address","attrs":[]},"snippets":[],"help":{"str":"","attrs":[]}}


### PR DESCRIPTION
The test checks https://bad@[fe:: which since curl 7.88.1 reports back "Bad IPv6 address" (CURLUE_BAD_IPV6). Previously it reported back "Port number was not a decimal number between 0 and 65535" (CURLUE_BAD_PORT_NUMBER).

Curl upstream changed in
https://github.com/curl/curl/commit/8b27799f8c5e51187533edb04c66dd9079e1c478 the port number function extraction, as the port number function does not need to fully verify the IPv6 address.

Fixes: #1128
Link: https://bugs.debian.org/1032539