### PR TITLE
Cursor-mode extension "snap to line"

### DIFF
--- a/docs/schemas/config-v1.schema.json
+++ b/docs/schemas/config-v1.schema.json
@@ -644,8 +644,8 @@
                                 "cursor"
                             ]
                         },
-                        "snap-in-offset": {
-                            "title": "/ui/movement/snap-in-offset",
+                        "snap-to-offset": {
+                            "title": "/ui/movement/snap-to-offset",
                             "description": "Offset in lines from the top line the cursor snaps in to. A negative value disables 'snapping' to a line, a value of 0 is effectively the same as 'top' mode, but with a visible cursor. Note: The limit should be set to a number less then the number of lines that is likely to be displayed on the screen at once. If The value is larger than the number of displayed lines, the limit will not have any effect.",
                             "type": "integer"
                         }

--- a/docs/schemas/config-v1.schema.json
+++ b/docs/schemas/config-v1.schema.json
@@ -643,6 +643,11 @@
                                 "top",
                                 "cursor"
                             ]
+                        },
+                        "snap-in-offset": {
+                            "title": "/ui/movement/snap-in-offset",
+                            "description": "Offset in lines from the top line the cursor snaps in to. A negative value disables 'snapping' to a line, a value of 0 is effectively the same as 'top' mode, but with a visible cursor. Note: The limit should be set to a number less then the number of lines that is likely to be displayed on the screen at once. If The value is larger than the number of displayed lines, the limit will not have any effect.",
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false

--- a/src/listview_curses.cc
+++ b/src/listview_curses.cc
@@ -107,16 +107,24 @@ listview_curses::handle_key(int ch)
 
         case '\r':
         case 'j':
-        case KEY_DOWN:
+        case KEY_DOWN: {
+            vis_line_t height;
+            unsigned long width;
+
+            this->get_dimensions(height, width);
+
             if (this->is_selectable()
                 && (this->lv_selection_limit < 0
-                    || this->lv_selection < this->lv_selection_limit))
+                    || this->lv_selection < this->lv_selection_limit
+                    // case: selection reaches tail space
+                    || (this->lv_selection >= (this->lv_top + height
+                                               - this->lv_tail_space - 1_vl))))
             {
                 this->shift_selection(1);
             } else {
                 this->shift_top(1_vl);
             }
-            break;
+        } break;
 
         case 'k':
         case KEY_UP:

--- a/src/listview_curses.cc
+++ b/src/listview_curses.cc
@@ -164,7 +164,10 @@ listview_curses::handle_key(int ch)
             vis_line_t last_line(this->get_inner_height() - 1);
             vis_line_t tail_bottom(this->get_top_for_last_row());
 
-            if (this->is_selectable()) {
+            if (this->is_selectable() && this->lv_selection_limit < 0) {
+                this->set_selection(last_line);
+            } else if (this->is_selectable()) {
+                this->set_top(last_line - this->lv_selection_limit);
                 this->set_selection(last_line);
             } else if (this->get_top() == last_line) {
                 this->set_top(tail_bottom);

--- a/src/listview_curses.cc
+++ b/src/listview_curses.cc
@@ -108,7 +108,10 @@ listview_curses::handle_key(int ch)
         case '\r':
         case 'j':
         case KEY_DOWN:
-            if (this->is_selectable()) {
+            if (this->is_selectable()
+                && (this->lv_selection_limit < 0
+                    || this->lv_selection < this->lv_selection_limit))
+            {
                 this->shift_selection(1);
             } else {
                 this->shift_top(1_vl);
@@ -117,7 +120,14 @@ listview_curses::handle_key(int ch)
 
         case 'k':
         case KEY_UP:
-            if (this->is_selectable()) {
+            if (this->is_selectable()  // selectable and
+                && (this->lv_selection_limit < 0
+                    || this->lv_top
+                        == 0  // .. top is in view
+                              //|| this->lv_selection  // .. or selection is
+                              //    > this->lv_top + this->lv_selection_limit //
+                    ))
+            {
                 this->shift_selection(-1);
             } else {
                 this->shift_top(-1_vl);
@@ -126,10 +136,14 @@ listview_curses::handle_key(int ch)
 
         case 'b':
         case KEY_BACKSPACE:
-        case KEY_PPAGE:
+        case KEY_PPAGE: {
+            if (this->is_selectable() && this->lv_top == 0) {
+                this->set_selection(0_vl);
+            }
             this->shift_top(
                 -(this->rows_available(this->lv_top, RD_UP) - 1_vl));
             break;
+        }
 
         case ' ':
         case KEY_NPAGE:

--- a/src/listview_curses.cc
+++ b/src/listview_curses.cc
@@ -666,6 +666,7 @@ listview_curses::set_selection_internal(vis_line_t sel)
             this->invoke_scroll();
             return;
         }
+        log_debug("set_selection_internal(): sel: %d", sel);
 
         unsigned long width;
         vis_line_t height;

--- a/src/listview_curses.cc
+++ b/src/listview_curses.cc
@@ -565,9 +565,12 @@ listview_curses::set_top(vis_line_t top, bool suppress_flash)
                     }
                 }
                 // selection was "snapped in" before changing top
-                if (this->lv_snap_to_top_offset >= 0 && snapped
-                    && this->lv_snap_to_top_offset
-                        < (height - this->lv_tail_space))
+                if (snapped
+                    && ((this->lv_snap_to_top_offset >= 0
+                         && previous_top > this->get_top())
+                        || (this->lv_snap_to_top_offset > 0
+                            && this->lv_snap_to_top_offset
+                                < (height - this->lv_tail_space))))
                 {
                     auto diff = this->get_top() - previous_top;
                     this->shift_selection(diff);
@@ -692,14 +695,16 @@ listview_curses::set_selection_internal(vis_line_t sel)
             if (found) {
                 this->lv_selection = sel;
 
-                if (this->lv_snap_to_top_offset >= 0_vl
+                if (this->lv_snap_to_top_offset > 0_vl  // not == 0!
                     && this->lv_snap_to_top_offset < height
                     && sel > this->lv_snap_to_top_offset
-                    && sel < this->get_top() + this->lv_snap_to_top_offset)
+                    && sel < (this->get_top() + this->lv_snap_to_top_offset))
                 {
                     this->lv_selection
                         = std::min(this->lv_top + this->lv_snap_to_top_offset,
                                    this->get_bottom());
+                } else if (this->lv_snap_to_top_offset == 0_vl) {
+                    this->lv_top = this->lv_selection;
                 }
                 this->lv_source->listview_selection_changed(*this);
                 this->set_needs_update();

--- a/src/listview_curses.cc
+++ b/src/listview_curses.cc
@@ -666,7 +666,6 @@ listview_curses::set_selection_internal(vis_line_t sel)
             this->invoke_scroll();
             return;
         }
-        log_debug("set_selection_internal(): sel: %d", sel);
 
         unsigned long width;
         vis_line_t height;

--- a/src/listview_curses.hh
+++ b/src/listview_curses.hh
@@ -544,6 +544,8 @@ protected:
         }
     }
 
+    void set_selection_internal(vis_line_t sel);
+
     enum class lv_mode_t {
         NONE,
         DOWN,

--- a/src/listview_curses.hh
+++ b/src/listview_curses.hh
@@ -520,21 +520,20 @@ public:
     virtual void invoke_scroll() { this->lv_scroll(this); }
 
     /**
-     * Sets the limit (from the top) the selection will 'lock in' to when
-     * reached
+     * Sets the line offset from top to snap the selection to when reached.
      *
-     * Setting the limit to a negative value will disable the limit.
-     * Setting the limit to 0 will essentially enable 'top' mode, but with a
-     * visible cursor.
+     * Setting the snap-to offset to a negative value will disable snapping
+     * Setting the snap-to offset to 0 will essentially enable 'top' mode, but
+     * with a visible cursor.
      *
      * @param limit the limit to set
      */
-    listview_curses& set_selection_limit(int limit)
+    listview_curses& set_snap_to_offset(int limit)
     {
-        this->lv_selection_limit = vis_line_t{limit};
+        this->lv_snap_to_top_offset = vis_line_t{limit};
         return *this;
     }
-    int get_selection_limit() { return this->lv_selection_limit; }
+    int get_selection_limit() { return this->lv_snap_to_top_offset; }
 
 protected:
     void delegate_scroll_out()
@@ -566,7 +565,7 @@ protected:
     vis_line_t lv_top{0}; /*< The line at the top of the view. */
     unsigned int lv_left{0}; /*< The column at the left of the view. */
     vis_line_t lv_height{0}; /*< The abs/rel height of the view. */
-    vis_line_t lv_selection_limit{5}; /*< The abs/rel height of the view. */
+    vis_line_t lv_snap_to_top_offset{5}; /*< The snap-to line offset from top */
     int lv_history_position{0};
     bool lv_overlay_needs_update{true};
     bool lv_show_scrollbar{true}; /*< Draw the scrollbar in the view. */

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -2662,10 +2662,12 @@ SELECT tbl_name FROM sqlite_master WHERE sql LIKE 'CREATE VIRTUAL TABLE%'
         .add_input_delegate(lnav_data.ld_log_source)
         .set_tail_space(2_vl)
         .set_overlay_source(log_fos)
-        .set_selectable(selectable);
+        .set_selectable(selectable)
+        .set_selection_limit(lnav_config.lc_ui_movement.snap_in_line);
     lnav_data.ld_views[LNV_TEXT]
         .set_sub_source(&lnav_data.ld_text_source)
-        .set_selectable(selectable);
+        .set_selectable(selectable)
+        .set_selection_limit(lnav_config.lc_ui_movement.snap_in_line);
     lnav_data.ld_views[LNV_HISTOGRAM].set_sub_source(
         &lnav_data.ld_hist_source2);
     lnav_data.ld_views[LNV_DB].set_sub_source(&lnav_data.ld_db_row_source);

--- a/src/lnav.cc
+++ b/src/lnav.cc
@@ -2663,11 +2663,11 @@ SELECT tbl_name FROM sqlite_master WHERE sql LIKE 'CREATE VIRTUAL TABLE%'
         .set_tail_space(2_vl)
         .set_overlay_source(log_fos)
         .set_selectable(selectable)
-        .set_selection_limit(lnav_config.lc_ui_movement.snap_in_line);
+        .set_snap_to_offset(lnav_config.lc_ui_movement.snap_to_offset);
     lnav_data.ld_views[LNV_TEXT]
         .set_sub_source(&lnav_data.ld_text_source)
         .set_selectable(selectable)
-        .set_selection_limit(lnav_config.lc_ui_movement.snap_in_line);
+        .set_snap_to_offset(lnav_config.lc_ui_movement.snap_to_offset);
     lnav_data.ld_views[LNV_HISTOGRAM].set_sub_source(
         &lnav_data.ld_hist_source2);
     lnav_data.ld_views[LNV_DB].set_sub_source(&lnav_data.ld_db_row_source);

--- a/src/lnav_config.cc
+++ b/src/lnav_config.cc
@@ -539,7 +539,7 @@ static const struct json_path_container movement_handlers = {
         .with_example("cursor")
         .with_description("The mode of cursor movement to use.")
         .for_field<>(&_lnav_config::lc_ui_movement, &movement_config::mode),
-    yajlpp::property_handler("snap-in-offset")
+    yajlpp::property_handler("snap-to-offset")
         .with_synopsis("offset")
         .with_description(
             "Offset in lines from the top line the cursor snaps in to. "
@@ -550,7 +550,7 @@ static const struct json_path_container movement_handlers = {
             "The value is larger than the number of displayed lines, the limit "
             "will not have any effect.")
         .for_field<>(&_lnav_config::lc_ui_movement,
-                     &movement_config::snap_in_line),
+                     &movement_config::snap_to_offset),
 };
 
 static const struct json_path_container global_var_handlers = {

--- a/src/lnav_config.cc
+++ b/src/lnav_config.cc
@@ -539,6 +539,18 @@ static const struct json_path_container movement_handlers = {
         .with_example("cursor")
         .with_description("The mode of cursor movement to use.")
         .for_field<>(&_lnav_config::lc_ui_movement, &movement_config::mode),
+    yajlpp::property_handler("snap-in-offset")
+        .with_synopsis("offset")
+        .with_description(
+            "Offset in lines from the top line the cursor snaps in to. "
+            "A negative value disables 'snapping' to a line, a value of 0 is "
+            "effectively the same as 'top' mode, but with a visible cursor. "
+            "Note: The limit should be set to a number less then the number of "
+            "lines that is likely to be displayed on the screen at once. If "
+            "The value is larger than the number of displayed lines, the limit "
+            "will not have any effect.")
+        .for_field<>(&_lnav_config::lc_ui_movement,
+                     &movement_config::snap_in_line),
 };
 
 static const struct json_path_container global_var_handlers = {

--- a/src/lnav_config.hh
+++ b/src/lnav_config.hh
@@ -92,7 +92,7 @@ enum class config_movement_mode : unsigned int {
 
 struct movement_config {
     config_movement_mode mode;
-    int snap_in_line{-1};
+    int snap_to_offset{-1};
 };
 
 struct _lnav_config {

--- a/src/lnav_config.hh
+++ b/src/lnav_config.hh
@@ -92,6 +92,7 @@ enum class config_movement_mode : unsigned int {
 
 struct movement_config {
     config_movement_mode mode;
+    int snap_in_line{-1};
 };
 
 struct _lnav_config {

--- a/src/views_vtab.cc
+++ b/src/views_vtab.cc
@@ -190,7 +190,7 @@ CREATE TABLE lnav_views (
     search TEXT,            -- The text to search for in the view.
     filtering INTEGER,      -- Indicates if the view is applying filters.
     movement TEXT,          -- The movement mode, either 'top' or 'cursor'.
-    snap_in_line INTEGER,   -- The limit in "lines from top" for the cursor movement
+    snap_to_offset INTEGER,   -- The limit in "lines from top" for the cursor movement
     top_meta TEXT           -- A JSON object that contains metadata related to the top line in the view.
 );
 )";
@@ -377,7 +377,7 @@ CREATE TABLE lnav_views (
                    const char* search,
                    bool do_filtering,
                    string_fragment movement,
-                   int64_t snap_in_line,
+                   int64_t snap_to_offset,
                    const char* top_meta)
     {
         auto& tc = lnav_data.ld_views[index];
@@ -451,7 +451,7 @@ CREATE TABLE lnav_views (
         }
         if (movement == "top") {
             tc.set_selectable(false);
-            tc.set_selection_limit(-1);
+            tc.set_snap_to_offset(-1);
         } else if (movement == "cursor") {
             // First, toggle modes, otherwise get_selection() returns top
             tc.set_selectable(true);
@@ -466,7 +466,7 @@ CREATE TABLE lnav_views (
                 tc.set_selection(cur_bot);
             }
 
-            tc.set_selection_limit(snap_in_line);
+            tc.set_snap_to_offset(snap_to_offset);
         }
         tc.set_left(left);
         tc.set_paused(is_paused);


### PR DESCRIPTION
Adds an additional cursor-movement related config option for setting an offset from the top line.
The cursor snaps to this line when reached (from line 0) and stays there unless it is moved to a line before `top + offset` again.
This allows the first lines between line 0 and `offset` to still be reachable by the cursor.
Sane values for the offset are between 0 and window (content) height, negative values (-1) disable the new extension for a free movement of the cursor.

Cursor mode must be enabled for this to work.

Relates to: #1088.