### PR TITLE
strnatcmp.c: ensure correct value range for isdigit() argument.

### DIFF
--- a/src/base/strnatcmp.c
+++ b/src/base/strnatcmp.c
@@ -275,13 +275,13 @@ int ipv4cmp(int a_len, nat_char const *a,
     }
 
     for (; ai < a_len; ai++) {
-        if (!isdigit(a[ai]) || a[ai] != '.') {
+        if (!isdigit((unsigned char)a[ai]) || a[ai] != '.') {
             return 0;
         }
     }
 
     for (; bi < b_len; bi++) {
-        if (!isdigit(b[bi]) || b[bi] != '.') {
+        if (!isdigit((unsigned char)b[bi]) || b[bi] != '.') {
             return 0;
         }
     }


### PR DESCRIPTION
The valid values to pass to `isdigit()` is the values represented by `unsigned char` and the value of EOF (usually -1).  Other values such as the other negative `signed char` values may invoke undefined behaviour.

Fix this by casting the argument to `isdigit()` to `unsigned char`.

Found by building on NetBSD/macppc with -Wchar-subscripts turned on.