### PR TITLE
ArenaAlloc/arenaallocimpl.h: avoid shift overflow on 32-bit hosts.

### DIFF
--- a/src/third-party/ArenaAlloc/arenaallocimpl.h
+++ b/src/third-party/ArenaAlloc/arenaallocimpl.h
@@ -13,6 +13,8 @@
 #include <stdio.h>
 #endif
 
+#include <stdint.h>
+
 namespace ArenaAlloc
 {
 
@@ -108,7 +110,9 @@ namespace ArenaAlloc
       value |= value >> 4;
       value |= value >> 8;
       value |= value >> 16;
+#if SIZE_MAX > UINT32_MAX
       value |= value >> 32;
+#endif
 
       return value + 1;            
     }


### PR DESCRIPTION
Use the constants defined by <stdint.h> to avoid right-shift by 32 on a 32-bit host by comparing SIZE_MAX to UINT32_MAX, since `value` is a size_t.

Found by building on NetBSD/macppc with -Wshift-count-overflow (which is default on in the pkgsrc setup, which this is from).

./third-party/ArenaAlloc/arenaallocimpl.h:111:22: warning: right shift count >= width of type [-Wshift-count-overflow]
  111 |       value |= value >> 32;
      |                ~~~~~~^~~~~