### PR TITLE
Fix printing of `time_t` values.

### DIFF
--- a/src/command_executor.cc
+++ b/src/command_executor.cc
@@ -478,10 +478,10 @@ execute_sql(exec_context& ec, const std::string& sql, std::string& alt_msg)
                 snprintf(row_count_buf,
                          sizeof(row_count_buf),
                          ANSI_BOLD("%'d") " row%s matched in " ANSI_BOLD(
-                             "%ld.%03ld") " seconds",
+                             "%lld.%03ld") " seconds",
                          row_count,
                          row_count == 1 ? "" : "s",
-                         diff_tv.tv_sec,
+                         (long long)diff_tv.tv_sec,
                          std::max((long) diff_tv.tv_usec / 1000, 1L));
                 retval = row_count_buf;
                 if (dls.has_log_time_column()) {
@@ -624,7 +624,7 @@ execute_file(exec_context& ec, const std::string& path_and_args, bool multiline)
 
     vars["#"] = env_arg_name;
     for (size_t lpc = 0; lpc < split_args.size(); lpc++) {
-        snprintf(env_arg_name, sizeof(env_arg_name), "%lu", lpc);
+        snprintf(env_arg_name, sizeof(env_arg_name), "%lu", (long unsigned int)lpc);
         vars[env_arg_name] = split_args[lpc];
     }
     for (size_t lpc = 1; lpc < split_args.size(); lpc++) {

--- a/src/lnav_commands.cc
+++ b/src/lnav_commands.cc
@@ -226,8 +226,8 @@ com_adjust_log_time(exec_context& ec,
             snprintf(
                 buffer,
                 sizeof(buffer),
-                "info: log timestamps will be adjusted by %ld.%06ld seconds",
-                time_diff.tv_sec,
+                "info: log timestamps will be adjusted by %lld.%06ld seconds",
+                (long long)time_diff.tv_sec,
                 (long) time_diff.tv_usec);
 
             retval = buffer;
@@ -295,7 +295,7 @@ com_unix_time(exec_context& ec,
                      "%a %b %d %H:%M:%S %Y  %z %Z",
                      localtime(&u_time));
             len = strlen(ftime);
-            snprintf(ftime + len, sizeof(ftime) - len, " -- %ld", u_time);
+            snprintf(ftime + len, sizeof(ftime) - len, " -- %lld", (long long)u_time);
             retval = std::string(ftime);
         } else {
             return ec.make_error("invalid unix time -- {}", args[1]);

--- a/src/ptimec.hh
+++ b/src/ptimec.hh
@@ -333,7 +333,7 @@ ftime_s(char* dst, off_t& off_inout, ssize_t len, const struct exttm& tm)
 {
     time_t t = tm2sec(&tm.et_tm);
 
-    snprintf(&dst[off_inout], len - off_inout, "%ld", t);
+    snprintf(&dst[off_inout], len - off_inout, "%lld", (long long)t);
     off_inout = strlen(dst);
 }
 
@@ -391,7 +391,7 @@ ftime_q(char* dst, off_t& off_inout, ssize_t len, const struct exttm& tm)
 {
     time_t t = tm2sec(&tm.et_tm);
 
-    snprintf(&dst[off_inout], len - off_inout, "%lx", t);
+    snprintf(&dst[off_inout], len - off_inout, "%llx", (long long)t);
     off_inout = strlen(dst);
 }
 


### PR DESCRIPTION
There is no guarantee that `time_t` is a `long int`.  On NetBSD, `time_t` is a `long long int`.  And ... apparently there is no portable way to indicate a printf format for a `time_t` via sys/inttypes.h / int_fmtio.h.

So do the next best thing to improve portability to NetBSD and avoid the warning about mismatched format and argument type (-Wformat) by casting `time_t` to `long long` before printing, and use %lld as the format specifier.

In a similar vein, there's also no portable way to specify a suitable format for a `size_t`, so cast to `long unsigned int` and print with %lu.