### PR TITLE
[build/arm] Add support for arm binary compilation in CI jobs.

### DIFF
--- a/.github/workflows/bins.yml
+++ b/.github/workflows/bins.yml
@@ -23,7 +23,8 @@ jobs:
   build-musl:
     runs-on: ubuntu-latest
     container:
-      image: tstack/lnav-build:1
+      image: tstack/lnav-build:latest
+      options: --platform linux/amd64
     env:
       LNAV_BASENAME: lnav-${{ inputs.lnav_version_number }}
       LNAV_ZIPNAME: lnav-${{ inputs.lnav_version_number }}-x86_64-linux-musl.zip

--- a/.github/workflows/bins.yml
+++ b/.github/workflows/bins.yml
@@ -27,7 +27,7 @@ jobs:
       options: --platform linux/amd64
     env:
       LNAV_BASENAME: lnav-${{ inputs.lnav_version_number }}
-      LNAV_ZIPNAME: lnav-${{ inputs.lnav_version_number }}-x86_64-linux-musl.zip
+      LNAV_ZIPNAME: lnav-${{ inputs.lnav_version_number }}-linux-musl-x86_64.zip
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -60,13 +60,19 @@ jobs:
           asset_name: ${{ env.LNAV_ZIPNAME }}
           asset_content_type: application/octet-stream
 
-  build-musl-armv7l:
+  build-arm:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - container-platform: linux/arm/v7
+            arch: armv7l
+          - container-platform: linux/arm64
+            arch: aarch64
     env:
       LNAV_BASENAME: lnav-${{ inputs.lnav_version_number }}
-      LNAV_ZIPNAME: lnav-${{ inputs.lnav_version_number }}-armv7l-linux-musl.zip
-      LNAV_ARTIFACT: lnav-linux-musl-armv7l.zip
-      CONT_PLATFORM: linux/arm/v7
+      LNAV_ZIPNAME: lnav-${{ inputs.lnav_version_number }}-linux-musl-${{ matrix.arch }}.zip
+      LNAV_ARTIFACT: lnav-linux-musl-${{ matrix.arch }}.zip
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -76,53 +82,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: tstack/lnav-build:latest
-          options: -v ${{ github.workspace }}:/lnav -e GITHUB_WORKSPACE=/lnav --platform ${{ env.CONT_PLATFORM }}
-          run: /entrypoint.sh
-      - name: Build musl package
-        if: ${{ inputs.lnav_version_number != '' }}
-        run: >-
-          cd ${{ github.workspace }}
-          mkdir ${{ env.LNAV_BASENAME }} &&
-          cd ${{ env.LNAV_BASENAME }} &&
-          cp ../NEWS.md ../README . &&
-          cp ../lbuild/src/lnav . &&
-          cd .. &&
-          zip -r ${{ env.LNAV_ZIPNAME }} ${{ env.LNAV_BASENAME }}
-      - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v3
-        with:
-          # Artifact name
-          name: ${{ env.LNAV_ARTIFACT }}
-          # A file, directory or wildcard pattern that describes what to upload
-          path: ${{ github.workspace }}/lbuild/src/lnav
-      - name: Upload musl-binary archive
-        uses: actions/upload-release-asset@v1.0.2
-        if: ${{ inputs.upload_url != '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ inputs.upload_url }}
-          asset_path: ${{ github.workspace }}/${{ env.LNAV_ZIPNAME }}
-          asset_name: ${{ env.LNAV_ZIPNAME }}
-          asset_content_type: application/octet-stream
-
-  build-musl-arm64v8:
-    runs-on: ubuntu-latest
-    env:
-      LNAV_BASENAME: lnav-${{ inputs.lnav_version_number }}
-      LNAV_ZIPNAME: lnav-${{ inputs.lnav_version_number }}-aarch64-linux-musl.zip
-      LNAV_ARTIFACT: lnav-linux-musl-aarch64.zip
-      CONT_PLATFORM: linux/arm64
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: make
-        uses: addnab/docker-run-action@v3
-        with:
-          image: tstack/lnav-build:latest
-          options: -v ${{ github.workspace }}:/lnav -e GITHUB_WORKSPACE=/lnav --platform ${{ env.CONT_PLATFORM }}
+          options: -v ${{ github.workspace }}:/lnav -e GITHUB_WORKSPACE=/lnav --platform ${{ matrix.container-platform }}
           run: /entrypoint.sh
       - name: Build musl package
         if: ${{ inputs.lnav_version_number != '' }}

--- a/.github/workflows/bins.yml
+++ b/.github/workflows/bins.yml
@@ -20,7 +20,7 @@ on:
         type: string
 
 jobs:
-  build-musl:
+  build-musl-x86_64:
     runs-on: ubuntu-latest
     container:
       image: tstack/lnav-build:latest
@@ -46,7 +46,91 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           # Artifact name
-          name: lnav-linux-musl-64bit.zip
+          name: lnav-linux-musl-x86_64.zip
+          # A file, directory or wildcard pattern that describes what to upload
+          path: lbuild/src/lnav
+      - name: Upload musl-binary archive
+        uses: actions/upload-release-asset@v1.0.2
+        if: ${{ inputs.upload_url != '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ${{ env.LNAV_ZIPNAME }}
+          asset_name: ${{ env.LNAV_ZIPNAME }}
+          asset_content_type: application/octet-stream
+
+  build-musl-armv7l:
+    runs-on: ubuntu-latest
+    container:
+      image: tstack/lnav-build:latest
+      options: --platform linux/arm/v7
+    env:
+      LNAV_BASENAME: lnav-${{ inputs.lnav_version_number }}
+      LNAV_ZIPNAME: lnav-${{ inputs.lnav_version_number }}-armv7l-linux-musl.zip
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: make
+        run: /entrypoint.sh
+      - name: Build musl package
+        if: ${{ inputs.lnav_version_number != '' }}
+        run: >-
+          mkdir ${{ env.LNAV_BASENAME }} &&
+          cd ${{ env.LNAV_BASENAME }} &&
+          cp ../NEWS.md ../README . &&
+          cp ../lbuild/src/lnav . &&
+          cd .. &&
+          zip -r ${{ env.LNAV_ZIPNAME }} ${{ env.LNAV_BASENAME }}
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          # Artifact name
+          name: lnav-linux-musl-armv7l.zip
+          # A file, directory or wildcard pattern that describes what to upload
+          path: lbuild/src/lnav
+      - name: Upload musl-binary archive
+        uses: actions/upload-release-asset@v1.0.2
+        if: ${{ inputs.upload_url != '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ${{ env.LNAV_ZIPNAME }}
+          asset_name: ${{ env.LNAV_ZIPNAME }}
+          asset_content_type: application/octet-stream
+
+  build-musl-arm64v8:
+    runs-on: ubuntu-latest
+    container:
+      image: tstack/lnav-build:latest
+      options: --platform linux/arm64
+    env:
+      LNAV_BASENAME: lnav-${{ inputs.lnav_version_number }}
+      LNAV_ZIPNAME: lnav-${{ inputs.lnav_version_number }}-aarch64-linux-musl.zip
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: make
+        run: /entrypoint.sh
+      - name: Build musl package
+        if: ${{ inputs.lnav_version_number != '' }}
+        run: >-
+          mkdir ${{ env.LNAV_BASENAME }} &&
+          cd ${{ env.LNAV_BASENAME }} &&
+          cp ../NEWS.md ../README . &&
+          cp ../lbuild/src/lnav . &&
+          cd .. &&
+          zip -r ${{ env.LNAV_ZIPNAME }} ${{ env.LNAV_BASENAME }}
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          # Artifact name
+          name: lnav-linux-musl-aarch64.zip
           # A file, directory or wildcard pattern that describes what to upload
           path: lbuild/src/lnav
       - name: Upload musl-binary archive

--- a/.github/workflows/bins.yml
+++ b/.github/workflows/bins.yml
@@ -62,22 +62,24 @@ jobs:
 
   build-musl-armv7l:
     runs-on: ubuntu-latest
-    container:
-      image: tstack/lnav-build:latest
-      options: --platform linux/arm/v7
     env:
       LNAV_BASENAME: lnav-${{ inputs.lnav_version_number }}
       LNAV_ZIPNAME: lnav-${{ inputs.lnav_version_number }}-armv7l-linux-musl.zip
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: checkout
         uses: actions/checkout@v3
-      - name: make
-        run: /entrypoint.sh
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Run the armv7l Docker builder
+        uses: addnab/docker-run-action@v3
+        with:
+          image: tstack/lnav-build:latest
+          options: -v ${{ github.workspace }}:/lnav -e GITHUB_WORKSPACE=/lnav --platform linux/arm/v7
+          run: /entrypoint.sh
       - name: Build musl package
         if: ${{ inputs.lnav_version_number != '' }}
         run: >-
+          cd ${{ github.workspace }}
           mkdir ${{ env.LNAV_BASENAME }} &&
           cd ${{ env.LNAV_BASENAME }} &&
           cp ../NEWS.md ../README . &&
@@ -90,7 +92,7 @@ jobs:
           # Artifact name
           name: lnav-linux-musl-armv7l.zip
           # A file, directory or wildcard pattern that describes what to upload
-          path: lbuild/src/lnav
+          path: ${{ github.workspace }}/lbuild/src/lnav
       - name: Upload musl-binary archive
         uses: actions/upload-release-asset@v1.0.2
         if: ${{ inputs.upload_url != '' }}
@@ -98,7 +100,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ inputs.upload_url }}
-          asset_path: ${{ env.LNAV_ZIPNAME }}
+          asset_path: ${{ github.workspace }}/${{ env.LNAV_ZIPNAME }}
           asset_name: ${{ env.LNAV_ZIPNAME }}
           asset_content_type: application/octet-stream
 

--- a/.github/workflows/bins.yml
+++ b/.github/workflows/bins.yml
@@ -65,16 +65,18 @@ jobs:
     env:
       LNAV_BASENAME: lnav-${{ inputs.lnav_version_number }}
       LNAV_ZIPNAME: lnav-${{ inputs.lnav_version_number }}-armv7l-linux-musl.zip
+      LNAV_ARTIFACT: lnav-linux-musl-armv7l.zip
+      CONT_PLATFORM: linux/arm/v7
     steps:
       - name: checkout
         uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      - name: Run the armv7l Docker builder
+      - name: make
         uses: addnab/docker-run-action@v3
         with:
           image: tstack/lnav-build:latest
-          options: -v ${{ github.workspace }}:/lnav -e GITHUB_WORKSPACE=/lnav --platform linux/arm/v7
+          options: -v ${{ github.workspace }}:/lnav -e GITHUB_WORKSPACE=/lnav --platform ${{ env.CONT_PLATFORM }}
           run: /entrypoint.sh
       - name: Build musl package
         if: ${{ inputs.lnav_version_number != '' }}
@@ -90,7 +92,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           # Artifact name
-          name: lnav-linux-musl-armv7l.zip
+          name: ${{ env.LNAV_ARTIFACT }}
           # A file, directory or wildcard pattern that describes what to upload
           path: ${{ github.workspace }}/lbuild/src/lnav
       - name: Upload musl-binary archive
@@ -106,22 +108,26 @@ jobs:
 
   build-musl-arm64v8:
     runs-on: ubuntu-latest
-    container:
-      image: tstack/lnav-build:latest
-      options: --platform linux/arm64
     env:
       LNAV_BASENAME: lnav-${{ inputs.lnav_version_number }}
       LNAV_ZIPNAME: lnav-${{ inputs.lnav_version_number }}-aarch64-linux-musl.zip
+      LNAV_ARTIFACT: lnav-linux-musl-aarch64.zip
+      CONT_PLATFORM: linux/arm64
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: checkout
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: make
-        run: /entrypoint.sh
+        uses: addnab/docker-run-action@v3
+        with:
+          image: tstack/lnav-build:latest
+          options: -v ${{ github.workspace }}:/lnav -e GITHUB_WORKSPACE=/lnav --platform ${{ env.CONT_PLATFORM }}
+          run: /entrypoint.sh
       - name: Build musl package
         if: ${{ inputs.lnav_version_number != '' }}
         run: >-
+          cd ${{ github.workspace }}
           mkdir ${{ env.LNAV_BASENAME }} &&
           cd ${{ env.LNAV_BASENAME }} &&
           cp ../NEWS.md ../README . &&
@@ -132,9 +138,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           # Artifact name
-          name: lnav-linux-musl-aarch64.zip
+          name: ${{ env.LNAV_ARTIFACT }}
           # A file, directory or wildcard pattern that describes what to upload
-          path: lbuild/src/lnav
+          path: ${{ github.workspace }}/lbuild/src/lnav
       - name: Upload musl-binary archive
         uses: actions/upload-release-asset@v1.0.2
         if: ${{ inputs.upload_url != '' }}
@@ -142,7 +148,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ inputs.upload_url }}
-          asset_path: ${{ env.LNAV_ZIPNAME }}
+          asset_path: ${{ github.workspace }}/${{ env.LNAV_ZIPNAME }}
           asset_name: ${{ env.LNAV_ZIPNAME }}
           asset_content_type: application/octet-stream
 


### PR DESCRIPTION
This change adds support for creating statically linked arm (armv7l, aarch64) binaries in the CI jobs.

Re: #558 