### PR TITLE
[posts] Replace dead link with an archived link.

### DIFF
--- a/docs/_posts/2018-04-05-linux-magazine-tutorial.md
+++ b/docs/_posts/2018-04-05-linux-magazine-tutorial.md
@@ -5,5 +5,5 @@ date:   2018-04-05 00:00:00
 ---
 
 Looks like there was an in-depth
-[tutorial on lnav in Linux Magazine](http://www.linux-magazine.com/Issues/2017/196/Tutorials-lnav).
+[tutorial on lnav in Linux Magazine](https://web.archive.org/web/20230130154739/http://www.linux-magazine.com/Issues/2017/196/Tutorials-lnav).
 Unfortunately, I didn't notice until now and missed out on a hardcopy.


### PR DESCRIPTION
The link to linuxmagazine is dead. Replacing it with the last archived link on the wayback machine.