### PR TITLE
last-word shortening algorithm added

### DIFF
--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -227,6 +227,8 @@ object with the following fields:
       :truncate: Truncates any text past the maximum width.
       :dot-dot: Cuts out the middle of the text and replaces it with two
         dots (i.e. '..').
+      :last-word: Removes all but the last word in dotted text. For example,
+        "com.example.foo" would be shortened to "foo".
 
     (v0.8.2+)
   :timestamp-format: The timestamp format to use when displaying the time

--- a/src/base/string_util.cc
+++ b/src/base/string_util.cc
@@ -199,6 +199,34 @@ is_url(const std::string& fn)
 }
 
 size_t
+last_word_str(char* str, size_t len, size_t max_len)
+{
+    if (len < max_len) {
+        return len;
+    }
+
+    size_t last_start = 0;
+
+    for (size_t index = 0; index < len; index++) {
+        switch (str[index]) {
+            case '.':
+            case '-':
+            case '/':
+            case ':':
+                last_start = index + 1;
+                break;
+        }
+    }
+
+    if (last_start == 0) {
+        return len;
+    }
+
+    memmove(&str[0], &str[last_start], len - last_start);
+    return len - last_start;
+}
+
+size_t
 abbreviate_str(char* str, size_t len, size_t max_len)
 {
     size_t last_start = 1;

--- a/src/base/string_util.hh
+++ b/src/base/string_util.hh
@@ -228,6 +228,8 @@ bool is_blank(const std::string& str);
 
 size_t abbreviate_str(char* str, size_t len, size_t max_len);
 
+size_t last_word_str(char* str, size_t len, size_t max_len);
+
 void split_ws(const std::string& str, std::vector<std::string>& toks_out);
 
 std::string repeat(const std::string& input, size_t num);

--- a/src/log_format.cc
+++ b/src/log_format.cc
@@ -2280,6 +2280,13 @@ external_log_format::get_subline(const logline& ll,
                                             rest);
                                         break;
                                     }
+                                    case json_format_element::overflow_t::
+                                        LASTWORD: {
+                                        size_t new_size = last_word_str(&str[0], str.size(), jfe.jfe_max_width);
+                                        str.resize(new_size);
+                                        this->json_append(jfe, vd, str.data(), str.size());
+                                        break;
+                                    }
                                 }
                             } else {
                                 sub_offset

--- a/src/log_format_ext.hh
+++ b/src/log_format_ext.hh
@@ -231,6 +231,7 @@ public:
             ABBREV,
             TRUNCATE,
             DOTDOT,
+            LASTWORD,
         };
 
         enum class transform_t {

--- a/src/log_format_loader.cc
+++ b/src/log_format_loader.cc
@@ -456,6 +456,7 @@ static const json_path_handler_base::enum_value_t OVERFLOW_ENUM[] = {
     {"truncate",
      external_log_format::json_format_element::overflow_t::TRUNCATE},
     {"dot-dot", external_log_format::json_format_element::overflow_t::DOTDOT},
+    {"last-word", external_log_format::json_format_element::overflow_t::LASTWORD},
 
     json_path_handler_base::ENUM_TERMINATOR,
 };


### PR DESCRIPTION
Another useful field shortening algorithm added: "last-word"
```json
"line-format": [
            {
                "field": "logger",
                "overflow": "last-word",
                "max-width": 30,
                "min-width": 30,
                "align": "right"
            },
        ],
```

original log:
```log
2024-03-27 15:22:51.534 DEBUG com.example.digital.ms.excorporate.notification.business.services.implementation.CamelExecutor Get AccountDetailsDTO batchSize:10000, offset:0
2024-03-27 15:22:26.970 DEBUG com.example.digital.ms.excorporate.notification.couchbase.NotificationRepositorylistCorpUsageProcessor:: [QueryResultWithTotal{data=null, total=9}]
```

resulting log:
```log
2024-03-27T15:22:51.534 DEBUG                  CamelExecutor Get AccountDetailsDTO batchSize:10000, offset:0 
2024-03-27T15:22:26.970 DEBUG         NotificationRepository listCorpUsageProcessor:: [QueryResultWithTotal{data=null, total=9}]                                                                                                           │
```
