### PR TITLE
doc: custom log config files need to end in `_log.json` not just `.json`

### DIFF
--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -72,7 +72,7 @@ Defining a New Format
 New log formats can be defined by placing JSON configuration files in
 subdirectories of the :file:`/etc/lnav/formats` and :file:`~/.lnav/formats/`
 directories. The directories and files can be named anything you like, but the
-files must have the '.json' suffix.  A sample file containing the builtin
+files must have the '_log.json' suffix.  A sample file containing the builtin
 configuration will be written to this directory when **lnav** starts up.
 You can consult that file when writing your own formats or if you need to
 modify existing ones.  Format directories can also contain '.sql' and '.lnav'


### PR DESCRIPTION
I struggled to find out why I couldn't get SQL queries to work on my otherwise functioning custom log file.

When trying out another custom log file from a PR I realized that my file was called `postgresCustom.json` and all other log files were ending in `_log.json` (mine wasn't).

When I added the magic `_log.json` SQL finally started working!

Mentioning this in the docs is a good start. It would be even better if this was validated and logged in the debug logs.

For example, I created the custom config via the regex101 importer like this:

```
lnav -m regex101 import https://regex101.com/r/5CZxWI/1 postgresCustom
```

The importer should have either complained that I must end the file name in `_log`, e.g. `postgresCustom_log`, or it should have simply appended that `_log` suffix.