### PR TITLE
Simplify nextcloud_log format

### DIFF
--- a/src/formats/nextcloud_log.json
+++ b/src/formats/nextcloud_log.json
@@ -21,7 +21,15 @@
         "multiline": false,
         "value": {
             "exception": {
-                "kind": "json"
+                "kind": "json",
+                "hidden": true
+            },
+            "exception/Exception": {
+                "kind": "string",
+                "identifier": true
+            },
+            "exception/Message": {
+                "kind": "string"
             },
             "app": {
                 "kind": "string",
@@ -36,14 +44,29 @@
                 "identifier": true
             },
             "url": {
-                "kind": "string"
+                "kind": "string",
+                "hidden": true
             },
             "method": {
-                "kind": "string"
+                "kind": "string",
+                "hidden": true
             },
             "user": {
                 "kind": "string",
-                "identifier": true
+                "identifier": true,
+                "hidden": true
+            },
+            "userAgent": {
+                "kind": "string",
+                "hidden": true
+            },
+            "version": {
+                "kind": "string",
+                "hidden": true
+            },
+            "data": {
+                "kind": "json",
+                "hidden": true
             }
         },
         "line-format": [
@@ -79,6 +102,22 @@
             " ",
             {
                 "field": "message"
+            },
+            {
+                "field": "exception/Exception",
+                "prefix": "\t\t",
+                "suffix": "",
+                "default-value": ""
+            },
+            {
+                "field": "exception/Message",
+                "prefix": ": \u201c",
+                "suffix": "\u201d",
+                "default-value": ""
+            },
+            {
+                "field": "data",
+                "default-value": ""
             }
         ]
     }

--- a/src/formats/nextcloud_log.json
+++ b/src/formats/nextcloud_log.json
@@ -47,6 +47,12 @@
             }
         },
         "line-format": [
+            "[",
+            {
+                "field": "__level__",
+                "text-transform": "uppercase"
+            },
+            "] ",
             {
                 "field": "__timestamp__"
             },
@@ -59,16 +65,16 @@
             " ",
             {
                 "field": "remoteAddr",
-                "min-width": 15
+                "min-width": 9,
+                "max-width": 9,
+                "overflow": "dot-dot"
             },
             " ",
             {
-                "field": "__level__",
-                "text-transform": "uppercase"
-            },
-            " ",
-            {
-                "field": "app"
+                "field": "app",
+                "min-width": 12,
+                "max-width": 12,
+                "overflow": "truncate"
             },
             " ",
             {


### PR DESCRIPTION
First of all, thanks a lot for lnav.
We at nextcloud have been using it for quite a while, but I never found the time to upstream the config we were using.

Since the update to Ubuntu 24.04 and therefor getting the "new lnav" (> 0.10) our old config did not work anymore and now I discovered you are shipping a nextcloud one already.

I don't know if there are "rules" for the logs, but I find it much easier with these small changes:
- level at the beginning, so it can be "navigated away", or skipped as the color helps already
- shorten IP (v6 is taking quite some space otherwise)
- consistent length of app id
- added exception class (with color identifier) and message
- added hint for data array

### Sample screenshot
![grafik](https://github.com/user-attachments/assets/13019fbd-2d42-47cf-afbc-e412247f96a3)


~~The other thing I couldn't figure out is how to get rid of the "always displayed" user+method+url+exception fields. they make "scanning" for relevant things quite complex, but it doesn't seem to be related to the format? Is it coming from something else?~~