### PR TITLE
fix parsing dates with months abbreviated in some locales

### DIFF
--- a/test/test_date_time_scanner.cc
+++ b/test/test_date_time_scanner.cc
@@ -203,6 +203,7 @@ TEST_CASE("date_time_scanner")
     {
         const char* en_date = "Jan  1 12:00:00";
         const char* fr_date = "août 19 11:08:37";
+        const char* fr_date2 = "nov. 29 20:23:37";
         struct timeval en_tv, fr_tv;
         struct exttm en_tm, fr_tm;
         date_time_scanner dts;
@@ -212,6 +213,9 @@ TEST_CASE("date_time_scanner")
                    != nullptr);
             dts.clear();
             assert(dts.scan(fr_date, strlen(fr_date), nullptr, &fr_tm, fr_tv)
+                   != nullptr);
+            dts.clear();
+            assert(dts.scan(fr_date2, strlen(fr_date), nullptr, &fr_tm, fr_tv)
                    != nullptr);
         }
     }


### PR DESCRIPTION
Current code first attempts to detect english abbreviations for %b and only if the string does not start with one of the months, tries the locale specific names.

This is incorrect for some locales.
For example in fr_FR %b for november is `nov.`. Parsing `nov. 29` as `%b %d` would fail because we wrongly assume that the month is just `nov` and not `nov.`. Then we attempt to parse `. 29` as ` %d`.

The correct solution would be to try english and if later the string does not match to backtrack, but this does not match the existing flow of the code.

Instead this restricts the fast path to matching full words to the english locale, not only prefixes.

Fixes: https://github.com/tstack/lnav/issues/1086