### PR TITLE
[tests] Substitute prefix path to lnav -nf sample in expected help text

### DIFF
--- a/test/expected/test_cmds.sh_b6a3bb78e9d60e5e1f5ce5b18e40d2f1662707ab.out
+++ b/test/expected/test_cmds.sh_b6a3bb78e9d60e5e1f5ce5b18e40d2f1662707ab.out
@@ -78,7 +78,7 @@ you can pass the [37m[40m -n [0m option. This combination of options allows y
 to write scripts for processing logs with lnav. For example, to get a
 list of IP addresses that dhclient has bound to in CSV format:
 
- ▌[32m[40m#! /usr/bin/lnav -nf                                                                            [0m
+ ▌[32m[40m#! {prefix}/bin/lnav -nf                                                                            [0m
  ▌[37m[40m                                                                                                [0m
  ▌[32m[40m# Usage: dhcp_ip.lnav /var/log/messages                                                         [0m
  ▌[32m[40m# Only include lines that look like:                                                            [0m

--- a/test/expected_help.txt
+++ b/test/expected_help.txt
@@ -84,7 +84,7 @@ UI, you can pass the  -n  option. This combination of options allows
 you to write scripts for processing logs with lnav. For example, to 
 get a list of IP addresses that dhclient has bound to in CSV format:
 
- ┃#! /usr/bin/lnav -nf                                                                            
+ ┃#! {prefix}/bin/lnav -nf                                                                            
  ┃                                                                                                
  ┃# Usage: dhcp_ip.lnav /var/log/messages                                                         
  ┃# Only include lines that look like:                                                            


### PR DESCRIPTION
Commit 697f25600ba7 ("[tests] sub some more variables in expected output") introduced new replacements for ${prefix} occurences. In case where prefix is /usr the TESTS_ENVIRONMENT will additionally replace the occurence of

	#! /usr/bin/lnav -nf

with a

	#! {prefix}/bin/lnav -nf

and causing the test_cmds.sh to fail.

Fixes: 697f25600ba7 ("[tests] sub some more variables in expected output")
Fixes: #1345