### PR TITLE
Expand demultiplex documentation

### DIFF
--- a/docs/schemas/config-v1.schema.json
+++ b/docs/schemas/config-v1.schema.json
@@ -979,7 +979,7 @@
                             "properties": {
                                 "enabled": {
                                     "title": "/log/demux/<name>/enabled",
-                                    "description": "Indicates whether this demuxer will be used at the demuxing stage",
+                                    "description": "Indicates whether this demuxer will be used at the demuxing stage (defaults to 'true')",
                                     "type": "boolean"
                                 },
                                 "pattern": {


### PR DESCRIPTION
This is my suggestion on how to improve the demux docs.
I did change the structure of the page though. If you don't like that I can revert it!

I was initially very confused that directly below the "Demux" section I get the reference for watch expressions which is why I moved the reference directly underneath each section.

/fixes https://github.com/tstack/lnav/issues/1355