### PR TITLE
Fix cross rust2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,10 +48,32 @@ AC_PROG_INSTALL
 AC_PROG_RANLIB
 AM_PROG_AR
 AC_PROG_LN_S
+AC_PROG_GREP
 AC_PROG_MAKE_SET
 
 AC_PATH_PROG(BASH, [bash])
 AC_PATH_PROG(CARGO_CMD, [cargo])
+AC_PATH_PROG(RUSTC_CMD, [rustc])
+if test x"$RUSTC_CMD" == x""; then
+    RUSTC_PLATFORM=no
+else
+    # for example, rustc expects x86_64-unknown-linux-gnu instead of x86_64-pc-linux-gnu
+    # and armv7-unknown-linux-gnueabihf instead of armv7l-unknown-linux-gnueabihf
+    AC_MSG_CHECKING([rustc --target argument])
+    if "$RUSTC_CMD" --print target-list | $GREP "$host" > /dev/null; then
+        RUSTC_PLATFORM="$host"
+    else
+        candidate=`echo "$host_cpu"-unknown-"$host_os" | sed -e 's/armv\(.\)l-/armv\1-/'`
+        if "$RUSTC_CMD" --print target-list | $GREP "$candidate" > /dev/null; then
+            RUSTC_PLATFORM="$candidate"
+        else
+            AC_MSG_ERROR("$RUSTC_CMD knows neither $host nor $candidate")
+        fi
+    AC_MSG_RESULT(["$RUSTC_PLATFORM"])
+    fi
+fi
+AC_SUBST(RUSTC_PLATFORM)
+
 AC_PATH_PROG(BZIP2_CMD, [bzip2])
 AC_PATH_PROG(RE2C_CMD, [re2c])
 AM_CONDITIONAL(HAVE_RE2C, test x"$RE2C_CMD" != x"")

--- a/configure.ac
+++ b/configure.ac
@@ -54,23 +54,23 @@ AC_PROG_MAKE_SET
 AC_PATH_PROG(BASH, [bash])
 AC_PATH_PROG(CARGO_CMD, [cargo])
 AC_PATH_PROG(RUSTC_CMD, [rustc])
-if test x"$RUSTC_CMD" == x""; then
-    RUSTC_PLATFORM=no
-else
+RUSTC_PLATFORM=no
+if test x"$RUSTC_CMD" != x""; then
     # for example, rustc expects x86_64-unknown-linux-gnu instead of x86_64-pc-linux-gnu
     # and armv7-unknown-linux-gnueabihf instead of armv7l-unknown-linux-gnueabihf
+    # and x86_64-apple-darwin instead of x86_64-apple-darwin22.6.0
     AC_MSG_CHECKING([rustc --target argument])
-    if "$RUSTC_CMD" --print target-list | $GREP "$host" > /dev/null; then
-        RUSTC_PLATFORM="$host"
-    else
-        candidate=`echo "$host_cpu"-unknown-"$host_os" | sed -e 's/armv\(.\)l-/armv\1-/'`
-        if "$RUSTC_CMD" --print target-list | $GREP "$candidate" > /dev/null; then
+    candidate1=`echo "$host" | sed -e 's/armv\(@<:@0-9@:>@\)l-/armv\1-/' | sed -e 's/-darwin@<:@0-9.@:>@*/-darwin/'`
+    candidate2=`echo "$host_cpu"-unknown-"$host_os" | sed -e 's/armv\(@<:@0-9@:>@\)l-/armv\1-/' | sed -e 's/-darwin@<:@0-9.@:>@*/-darwin/'`
+    for candidate in $host $candidate1 $candidate2; do
+        if "$RUSTC_CMD" --print target-list | $GREP "^$candidate"'$' > /dev/null; then
             RUSTC_PLATFORM="$candidate"
-        else
-            AC_MSG_ERROR("$RUSTC_CMD knows neither $host nor $candidate")
         fi
-    AC_MSG_RESULT(["$RUSTC_PLATFORM"])
+    done
+    if test x"$RUSTC_PLATFORM" = x"no"; then
+        AC_MSG_ERROR("$RUSTC_CMD knows none of $host $candidate1 $candidate2")
     fi
+    AC_MSG_RESULT(["$RUSTC_PLATFORM"])
 fi
 AC_SUBST(RUSTC_PLATFORM)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -126,11 +126,11 @@ AM_CXXFLAGS = $(CODE_COVERAGE_CXXFLAGS) $(USER_CXXFLAGS)
 if HAVE_CARGO
 RUST_DEPS_CPPFLAGS = -DHAVE_RUST_DEPS=1
 PRQLC_DIR = third-party/prqlc-c/target
-RUST_DEPS_LIBS = $(PRQLC_DIR)/release/libprqlc_c.a
+RUST_DEPS_LIBS = $(PRQLC_DIR)/$(RUSTC_PLATFORM)/release/libprqlc_c.a
 
 $(RUST_DEPS_LIBS): $(srcdir)/third-party/prqlc-c/src/lib.rs $(srcdir)/third-party/prqlc-c/Cargo.toml
 	mkdir -p $(PRQLC_DIR)
-	env CARGO_TARGET_DIR=third-party/prqlc-c/target $(CARGO_CMD) build --manifest-path \
+	env CARGO_TARGET_DIR=third-party/prqlc-c/target $(CARGO_CMD) build --target $(RUSTC_PLATFORM) --manifest-path \
 	    $(srcdir)/third-party/prqlc-c/Cargo.toml --package prqlc-c --release
 
 else


### PR DESCRIPTION
fixes for the darwin issue in https://github.com/tstack/lnav/pull/1360#issuecomment-2564395405

I don't have access to darwin, tested by `autoreconf -fv && ./configure --host x86_64-apple-darwin22.6.0 CC=cc`

for the musl issue the error message is quite clear: to cross compile rust to musl you need the corresponding toolchain. How did it even work before?