### PR TITLE
register SQLITE_RESULT_SUBTYPE property for yaml_to_json

### DIFF
--- a/src/yaml-extension-functions.cc
+++ b/src/yaml-extension-functions.cc
@@ -98,7 +98,8 @@ yaml_extension_functions(struct FuncDef** basic_funcs,
                 .with_example({
                     "To convert the document \"abc: def\"",
                     "SELECT yaml_to_json('abc: def')",
-                })),
+                }))
+            .with_result_subtype(),
 
         {nullptr},
     };


### PR DESCRIPTION
Without this change, yaml_to_json failed on my machine with this error:
    error: SQL statement failed
    reason: misuse of sqlite3_result_subtype() by yaml_to_json()

And this results in dirty src/internals/sql-ref.rst after "make" every time.