### PR TITLE
[format] fixed syslog regex

### DIFF
--- a/src/formats/syslog_log.json
+++ b/src/formats/syslog_log.json
@@ -6,7 +6,7 @@
         "url": "http://en.wikipedia.org/wiki/Syslog",
         "regex": {
             "std": {
-                "pattern": "^(?<timestamp>(?:\\S{3,8}\\s+\\d{1,2} \\d{2}:\\d{2}:\\d{2}|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3,6})?(?:Z|(?:\\+|-)\\d{2}:\\d{2})))(?: (?<log_hostname>[a-zA-Z0-9:][^ ]+[a-zA-Z0-9]))?(?: \\[CLOUDINIT\\])?(?:(?: syslogd [\\d\\.]+|(?: (?<log_syslog_tag>(?<log_procname>(?:[^\\[:]+|[^ :]+))(?:\\[(?<log_pid>\\d+)\\](?: \\([^\\)]+\\))?)?))):\\s*(?<body>.*)$|:?(?:(?: ---)? last message repeated \\d+ times?(?: ---)?))"
+                "pattern": "^(?<timestamp>(?:\\S{3,8}\\s+\\d{1,2} \\d{2}:\\d{2}:\\d{2}|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3,6})?(?:Z|(?:\\+|-)\\d{2}:\\d{2})))(?: (?<log_hostname>[a-zA-Z0-9:][^ ]+[a-zA-Z0-9]))?(?: \\[CLOUDINIT\\])?(?:(?: syslogd [\\d\\.]+|(?: (?<log_syslog_tag>(?<log_procname>(?:[^\\[:]+|[^ :]+))(?:\\[(?<log_pid>[\\d\\.]+)\\](?: \\([^\\)]+\\))?)?))):?\\s*(?<body>.*)$|:?(?:(?: ---)? last message repeated \\d+ times?(?: ---)?))"
             },
             "rfc5424": {
                 "pattern": "^<(?<log_pri>\\d+)>(?<syslog_version>\\d+) (?<timestamp>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{6})?(?:[^ ]+)?) (?<log_hostname>[^ ]+|-) (?<log_syslog_tag>(?<log_procname>[^ ]+|-) (?<log_pid>[^ ]+|-) (?<log_msgid>[^ ]+|-)) (?<log_struct>\\[(?:[^\\]\"]|\"(?:\\.|[^\"])+\")*\\]|-|)\\s+(?<body>.*)"


### PR DESCRIPTION
Some lines in my `rsyslog` log files on Debian (the ones coming from the `imtcp` module) were not matched properly because of slight differences in the format of some fields :

- the `log_pid` field sometimes contains a point
- the `:` after the PID is sometimes missing

Here is an example :
`2025-04-21T12:24:51.761734+02:00 myhostname kernel [499130.569180] [UFW BLOCK] IN=enX0`...

I'm not sure if these differences are due to a misconfiguration on my part. I'm using the latest version of `rsyslog` with this configuration :
`$ActionFileDefaultTemplate RSYSLOG_FileFormat`.

This pull requests offers to fix this on the regex's side in case other users have the same issue.