### PR TITLE
First zellij log file format parser

### DIFF
--- a/src/formats/formats.am
+++ b/src/formats/formats.am
@@ -59,5 +59,6 @@ FORMAT_FILES = \
     $(srcdir)/%reldir%/web_robot_log.json \
     $(srcdir)/%reldir%/xmlrpc_log.json \
     $(srcdir)/%reldir%/zap_console_log.json \
+    $(srcdir)/%reldir%/zellij_log.json \
     $(srcdir)/%reldir%/zookeeper_log.json \
     $()

--- a/src/formats/zellij_log.json
+++ b/src/formats/zellij_log.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "https://lnav.org/schemas/format-v1.schema.json",
+    "zellijFmt": {
+        "title": "Zellij’s logs",
+        "description": "Zellij’s format file. Zellij is a terminal multiplexer",
+        "file-pattern": "^\/tmp\/zellij-\\d+\/zellij-log\/zellij.log$",
+        "regex": {
+            "zellijRgx": {
+                "pattern": "^(?<level>[A-Z]+) *\\|(?<module>\\S+) *\\| (?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{3}) \\[(?<module2>\\S+) *\\] \\[(?<src_file>.+):(?<src_line>\\d+)\\]: (?<body>.*)(?:\\n\\nCaused by:\\n(?<cause_body>(?:\\s{4}+.*)+))*$"
+            }
+        },
+        "timestamp-format": [
+            "%Y-%m-%d %H:%M:%S.%L"
+        ],
+        "level": {
+            "error": "ERROR",
+            "warning": "WARN",
+            "info": "INFO",
+            "debug": "DEBUG"
+        },
+        "value": {
+            "cause_body": {
+                "kind": "string"
+            },
+            "level": {
+                "kind": "string"
+            },
+            "module": {
+                "kind": "string"
+            },
+            "module2": {
+                "kind": "string"
+            },
+            "src_file": {
+                "kind": "string"
+            },
+            "src_line": {
+                "kind": "integer"
+            },
+            "timestamp": {
+                "kind": "string"
+            }
+        },
+        "sample": [
+            {
+                "line": "INFO   |zellij_client            | 2025-05-16 19:31:19.601 [main      ] [/home/zykino/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zellij-client-0.42.2/src/lib.rs:179]: Starting Zellij client! ",
+                "level": "info"
+            },
+            {
+                "line": "ERROR  |???                      | 2025-05-16 19:32:04.614 [pty_writer] [/home/zykino/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zellij-server-0.42.2/src/os_input_output.rs:567]: a non-fatal error occured\n\nCaused by:\n    0: failed to set terminal id 2 to size (0, 27)\n    1: failed to find terminal fd for id 2 ",
+                "level": "error"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Hello,

I’m new to `lnav` and it looks like a very good project that I would have a hard time to learn since it does not understand the log format of tools I’m developing against regularly. So I went ahead and created a "parser" (not sure how you call them) for [`zellij`](https://github.com/zellij-org/zellij/) which is a terminal multiplexer (a bit like `tmux` or `screen` but different).

I’m seeing 2 log variant and asked if there are others. I also asked if a "producer id" (`lnav`'s `opid-field`) could be added to quickly filter the server, each clients and each plugin’s instances. I also asked if they have better name for some capture groups (`module` and `module2` don’t feels good :sweat_smile:)

Anyway I have this 1st implementation where I have some questions/issues:
1) I filled the `"file-pattern"` field with the most common log file path. I’m not sure it is necessary (or even a good idea), since almost no other formats appear to have it.
1) The `cause_body` field is always `null`, I’m not sure why since `multiline` default to `true`. This is an optional field of multi-line log that regex101.com correctly detected.
    1) This field contains a backtrace (or close enough). At first I wanted to cut it in lines or event components `<cause_id>: <cause_log>`. Is this useful in your experience or too much? I did not achieved it on regex101.com, since I’m not sure how dynamically increment capture group’s names.

Note: I did not compile this branch, I’m hoping that test done using the file installed in `~/.config/lnav/formats/installed` give the same results as compiled in.