### PR TITLE
[pcap_log] Add support for snoop and btsnoop formats

### DIFF
--- a/src/formats/pcap_log.json
+++ b/src/formats/pcap_log.json
@@ -8,6 +8,8 @@
         "converter": {
             "header": {
                 "expr": {
+                    "snoop": ":header REGEXP '^736e6f6f70000000.*'",
+                    "btsnoop": ":header REGEXP '^6274736e6f6f7000.*'",
                     "pcapng": ":header REGEXP '^0a0d0d0a.{8}(?:1a2b3c4d|4d3c2b1a).*'",
                     "pcap": ":header REGEXP '^(?:a1b2c3d4|d4c3b2a1|a1b23c4d|4d3cb2a1).*'"
                 },


### PR DESCRIPTION
The snoop (RFC 1761) and BT snoop file formats can be parsed by wireshark (tshark). Since these files contain packet captures similar to the pcap format, we can reuse the pcap_log format to properly display snoop formats as well.

Before the patch:
![Screenshot 2025-05-27 164330](https://github.com/user-attachments/assets/88666741-7461-4d27-a791-f9b90c7219f0)
After the patch:
![Screenshot 2025-05-27 164243](https://github.com/user-attachments/assets/bd11a47d-beca-4d8a-9531-a2f08fefd64c)
