### PR TITLE
Add content interface to snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -21,6 +21,14 @@ plugs:
     read:
       - /etc/lnav
 
+slots:
+  lnav-bin:
+    interface: content
+    content: lnav
+    source:
+      read:
+        - $SNAP/bin
+
 apps:
   lnav:
     command: usr/bin/lnav


### PR DESCRIPTION
So that other snaps, e.g., the `juju-lnav` snap [1], can use the `lnav` binary.

[1] https://github.com/nicolasbock/juju-lnav/blob/main/snap/snapcraft.yaml#L36