### PR TITLE
Recognize strace openat calls

### DIFF
--- a/src/formats/strace_log.json
+++ b/src/formats/strace_log.json
@@ -7,7 +7,7 @@
         "multiline": false,
         "regex": {
             "std": {
-                "pattern": "^(?<timestamp>\\d{2}:\\d{2}:\\d{2}\\.\\d{6}|\\d+\\.\\d{6}) (?<syscall>\\w+)\\((?<body>.*)\\)\\s+=\\s+(?:(?<rc>[-\\w]+(?: \\((?<rc_extra>.+)\\))?)|\\?)(?: (?<errno>\\w+) \\([^\\)]+\\))?(?: <(?<duration>\\d+\\.\\d+)>)?$"
+                "pattern": "^(?<timestamp>\\d{2}:\\d{2}:\\d{2}\\.\\d{6}|\\d+\\.\\d{6}) (?<syscall>\\w+)\\((?<body>.*)\\)\\s+=\\s+(?:(?<rc>[-\\w]+(?: \\((?<rc_extra>.+)\\))?)|\\?)(?: (?<errno>\\w+) \\([^\\)]+\\))?(?: <(?<duration>\\d+\\.\\d+)>)?(?<openat>.*)?$"
             },
             "signal": {
                 "pattern": "^(?<timestamp>\\d{2}:\\d{2}:\\d{2}\\.\\d{6}|\\d+\\.\\d{6}) --- (?<signame>\\w+) (?<siginfo>.*) ---$"


### PR DESCRIPTION
Hey,

I noticed that `openat` syscall in `strace` output has some trailing information which broke the regex. I added this to the regex pattern.

I do have some concerns: 
- I do not have any large corpus of tests to confirm this change doesn't break anything besides "works on my machine"
- I am running strace with `strace -ff -yy`, I don't know what's the supported `strace` flags for lnav
- The added regex group is very general and will grab basically anything at the end of otherwise valid strace string. That seems somewhat risky

Example log:
[df.strace.112142.log](https://github.com/user-attachments/files/21738456/df.strace.112142.log)