### PR TITLE
[listview] fix jumping over very long lines with Page Up

### DIFF
--- a/src/listview_curses.cc
+++ b/src/listview_curses.cc
@@ -297,8 +297,13 @@ listview_curses::handle_key(const ncinput& ch)
             {
                 this->set_selection(0_vl);
             } else {
-                auto shift_amount
-                    = -(this->rows_available(this->lv_top, RD_UP) - 1_vl);
+                auto rows_avail = this->rows_available(this->lv_top, RD_UP);
+                if (rows_avail <= 1_vl) {
+                    // may happen in case of jumping over very long lines
+                    // and we need to garantee at least some movement
+                    rows_avail = 2_vl;
+                }
+                auto shift_amount = -(rows_avail - 1_vl);
                 this->shift_top(shift_amount);
             }
             break;


### PR DESCRIPTION
Hi, this fixes an issue with jumping over very long lines (that don't even fit on screen) (btw this's a common case in our logs) with "Page Up".
In such cases `rows_available` returns 1 and `shift_amount` evaluates to 0, meaning you can't progress towards the top. In the fix I ensured that `rows_available` has enough value to proceed, which is close to what has been done in "Page Down" code.

Note #1: I used this script to generate a text file to test on:
```
with open("test-big.log", "w") as f:
    f.writelines(f"before {i}\n" for i in range(1, 81))
    f.writelines(f"{i} ThisIsALongLine, " for i in range(1, 1500))
    f.write("\n")
    f.writelines(f"after {i}\n" for i in range(1, 81))

```