### PR TITLE
[bzlib] Fixed compilation error when bzlib not configured

### DIFF
--- a/src/line_buffer.cc
+++ b/src/line_buffer.cc
@@ -1493,6 +1493,7 @@ line_buffer::peek_range(file_range fr,
             buf.resize(rc);
             return Ok(std::move(buf));
         }
+#ifdef HAVE_BZLIB_H
         if (this->lb_bz_file) {
             lock_hack::guard guard;
             char scratch[32 * 1024];
@@ -1550,6 +1551,9 @@ line_buffer::peek_range(file_range fr,
             buf.resize(rc);
             return Ok(std::move(buf));
         }
+#else
+        assert(!this->lb_bz_file);
+#endif
     }
 
     auto rc = pread(this->lb_fd, buf.data(), fr.fr_size, fr.fr_offset);


### PR DESCRIPTION
If statement previously assumed that BZFILE was defined, causing a compilation error on devices where the library is not defined.

I added an `assert` statement just to be safe in case `this->lb_bz_file` is true for whatever reason.  I tested this by trying to open a bz2 compressed file and found out that it looks like this code path may not even be called.  There is newer code in `archive_manager::walk_archive_file` ([src/archive_manager.cc:383](https://github.com/tstack/lnav/blob/master/src/archive_manager.cc#L383)) that appears to extract the bz2 file before it is accessed in line_buffer.cc.  I confirmed that this already extracted archive is the one used when opening the file.  I also confirmed that the only reference to setting `lb_bz_file` to true is inside code already protected by `#ifdef HAVE_BZLIB_H`.