### PR TITLE
Fix horizontal offset when enabling word-wrap

### DIFF
--- a/src/views_vtab.cc
+++ b/src/views_vtab.cc
@@ -741,7 +741,11 @@ CREATE TABLE lnav_db.lnav_views (
             tc.set_overlay_selection(vis_line_t(vo.vo_overlay_focus.value()));
         }
         if (vo.vo_word_wrap) {
-            tc.set_word_wrap(vo.vo_word_wrap.value() == word_wrap_t::normal);
+            auto wrap_words = vo.vo_word_wrap.value() == word_wrap_t::normal;
+            tc.set_word_wrap(wrap_words);
+            if (wrap_words) {
+                left = 0; // reset horizontal scroll position
+            }
         }
         if (vo.vo_hidden_fields) {
             tc.set_hide_fields(vo.vo_hidden_fields.value()


### PR DESCRIPTION
When a view is scrolled horizontally (left > 0) with word-wrap disabled, enabling word-wrap doesn't reset horizontal offset and keep user stuck in that shifted view.

Reproduction steps:
- open a file with lines longer than your view
- disable wrap
- scroll right
- enable wrap
- now you don't see line beginnings and you're stuck in that horizontal offset until you disable wrap again.

Fix: reset that offset when word-wrap is enabled.