### PR TITLE
Create android_logcat_log.json

### DIFF
--- a/src/formats/android_logcat_log.json
+++ b/src/formats/android_logcat_log.json
@@ -1,0 +1,90 @@
+{
+    "$schema": "https://lnav.org/schemas/format-v1.schema.json",
+    "logcatFull": {
+        "description": "Format for Android Logcat supporting multiple format (brief, full, millis, nanos)",
+        "regex": {
+            "full": {
+                "pattern": "(?<time>\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3,})\\s+((?<uid>\\w+)\\s+)?(?<pid>\\d+)\\s+(?<tid>\\d+) (?<level>.) ((?<tag>\\w+)\\s*:)?(?<body>.*)"
+            },
+            "brieftime": {
+                "pattern": "^(?<time>\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3,}) (?<level>.)\\/(?<tag>\\w+)\\s*\\(\\s*(?<uid>\\d+)\\):(?<body>.*)$"
+            }
+        },
+        "partitions": {
+            "section ": {
+                "pattern": "^-+ switch to (.*)"
+            }
+        },
+        "ordered-by-time": true,
+        "timestamp-field": "time",
+        "timestamp-format": [
+            "%m-%d %H:%M:%S.%L",
+            "%m-%d %H:%M:%S.%f"
+        ],
+        "body-field": "body",
+        "level-field": "level",
+        "level": {
+            "fatal": "^F",
+            "error": "^E",
+            "warning": "^W",
+            "info": "^I",
+            "debug5": "^D",
+            "debug2": "^V"
+        },
+        "value": {
+            "level": {
+                "kind": "string"
+            },
+            "tag": {
+                "kind": "string",
+                "identifier": false
+            },
+            "time": {
+                "kind": "string"
+            },
+            "body": {
+                "kind": "string"
+            },
+            "uid": {
+                "kind": "string",
+                "identifier": true
+            },
+            "pid": {
+                "kind": "integer",
+                "identifier": true
+            },
+            "tid": {
+                "kind": "integer",
+                "identifier": true
+            }
+        },
+        "highlights": {
+            "package": {
+                "pattern": "((([a-z]+\\.){2,})[a-z]+)(?=[ '\"])",
+                "color": "#97d1F6"
+            }
+        },
+        "sample": [
+            {
+                "line": "05-26 11:18:41.509  1000 23402 23402 V VirtualCameraSession: processCaptureRequest: CaptureRequest { frameNumber:102 }   ",
+                "level": "debug2"
+            },
+            {
+                "line": "05-21 15:05:52.808  1047  1116  1240 E FMQ     : MQDescriptor is invalid or queue size is 0.",
+                "level": "error"
+            },
+            {
+                "line": "05-21 20:54:20.971  root  1215  1215 W [18:54:20.964683][dhd][wlan]dhd_dbg_verboselog_printf: Log print water mark is reached, console logs are dumped only to debug_dump file",
+                "level": "warning"
+            },
+            {
+                "line": "05-26 14:57:03.870 V/Configuration( 1766): Updating configuration, locales updated from [] to [en_US]",
+                "level": "debug2"
+            },
+            {
+                "line": "06-06 14:26:44.749 13850 13850 D ScreenSharingSample: MediaProjection.Callback#onStop() called",
+                "level": "debug5"
+            }
+        ]
+    }
+}

--- a/src/formats/formats.am
+++ b/src/formats/formats.am
@@ -2,6 +2,7 @@
 FORMAT_FILES = \
     $(srcdir)/%reldir%/access_log.json \
     $(srcdir)/%reldir%/alb_log.json \
+    $(srcdir)/%reldir%/android_logcat_log.json \
     $(srcdir)/%reldir%/block_log.json \
     $(srcdir)/%reldir%/bunyan_log.json \
     $(srcdir)/%reldir%/caddy_log.json \


### PR DESCRIPTION
Add a new format to support Android Logcat (`adb logcat`) output.

Also added the entry to `formats.am`

Android is widely used worldwide and its log format (logcat) has a stable structure which is easily parsed by lnav.

https://developer.android.com/tools/logcat

Logcat has multiple output format, this patch supports the default and the brief format.