### PR TITLE
Add FreeBSD install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ you the basics of operation:
 $ brew install lnav
 ```
 
+### FreeBSD
+
+```console
+$ pkg install lnav
+```
+
 ## Usage
 
 Simply point **lnav** at the files or directories you want to


### PR DESCRIPTION
I'm the current maintainer of the FreeBSD port. Since FreeBSD is not a pre-compiled target and it's cleaner to have it in the ports repository anyway, I thought I'd be nice for the README to mention it. Of course, feel free to dismiss the addition.