### PR TITLE
CMake: Build without vcpkg dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,24 +13,47 @@ project(
 
 include(cmake/project-is-top-level.cmake)
 include(cmake/variables.cmake)
+include(cmake/options.cmake)
 
 find_package(PkgConfig REQUIRED)
-find_package(unofficial-sqlite3 CONFIG REQUIRED)
-find_package(BZip2 REQUIRED)
-find_package(LibArchive REQUIRED)
-find_package(ZLIB REQUIRED)
-find_package(pcre2 CONFIG REQUIRED)
-find_package(CURL REQUIRED)
 
-set(lnav_LIBS
-        CURL::libcurl
-        unofficial::sqlite3::sqlite3
-        BZip2::BZip2
-        PCRE2::8BIT PCRE2::16BIT PCRE2::32BIT PCRE2::POSIX
-        LibArchive::LibArchive
-        ZLIB::ZLIB
-        ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/libunistring.a
-)
+if (LNAV_USE_VCPKG)
+    find_package(unofficial-sqlite3 CONFIG REQUIRED)
+    find_package(BZip2 REQUIRED)
+    find_package(LibArchive REQUIRED)
+    find_package(ZLIB REQUIRED)
+    find_package(pcre2 CONFIG REQUIRED)
+    find_package(CURL REQUIRED)
+
+    set(lnav_LIBS
+            CURL::libcurl
+            unofficial::sqlite3::sqlite3
+            BZip2::BZip2
+            PCRE2::8BIT PCRE2::16BIT PCRE2::32BIT PCRE2::POSIX
+            LibArchive::LibArchive
+            ZLIB::ZLIB
+            ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/libunistring.a
+    )
+else ()
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/packages)
+
+    find_package(SQLite3 REQUIRED)
+    find_package(BZip2 REQUIRED)
+    find_package(LibArchive REQUIRED)
+    find_package(ZLIB REQUIRED)
+    find_package(pcre2 REQUIRED)
+    find_package(CURL REQUIRED)
+    find_package(Unistring REQUIRED)
+
+    set(lnav_LIBS
+            CURL::libcurl
+            SQLite3::SQLite3
+            BZip2::BZip2
+            pcre2::pcre2
+            LibArchive::LibArchive
+            ZLIB::ZLIB
+            Unistring::Unistring)
+endif ()
 
 add_subdirectory(src)
 add_subdirectory(test)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,0 +1,1 @@
+option(LNAV_USE_VCPKG "When disabled, libraries from the build host are used" ON)

--- a/cmake/packages/FindUnistring.cmake
+++ b/cmake/packages/FindUnistring.cmake
@@ -1,0 +1,16 @@
+include(FindPackageHandleStandardArgs)
+
+find_library(UNISTRING_LIBRARY NAMES unistring)
+find_path(UNISTRING_HDR NAMES unistr.h)
+
+find_package_handle_standard_args(Unistring
+REQUIRED_VARS UNISTRING_LIBRARY UNISTRING_HDR)
+
+if (Unistring_FOUND)
+    mark_as_advanced(UNISTRING_LIBRARY)
+    mark_as_advanced(UNISTRING_HDR)
+    add_library(Unistring::Unistring UNKNOWN IMPORTED)
+    set_property(TARGET Unistring::Unistring PROPERTY IMPORTED_LOCATION ${UNISTRING_LIBRARY})
+    cmake_path(GET UNISTRING_HDR PARENT_PATH UNISTRING_HDR)
+    target_include_directories(Unistring::Unistring INTERFACE ${UNISTRING_HDR_DIR})
+endif ()

--- a/cmake/packages/Findpcre2.cmake
+++ b/cmake/packages/Findpcre2.cmake
@@ -1,0 +1,4 @@
+find_package(PkgConfig REQUIRED)
+
+pkg_search_module(pcre2 REQUIRED libpcre2-8 libpcre2-16 libpcre2-32 libpcre2-posix IMPORTED_TARGET GLOBAL)
+add_library(pcre2::pcre2 ALIAS PkgConfig::pcre2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,7 +148,7 @@ add_custom_command(
         DEPENDS ptimec
         COMMAND ptimec ${TIME_FORMATS} > time_fmts.cc)
 
-add_library(lnavdt STATIC config.h.in ptimec.hh ptimec_spec.hh ptimec_rt.cc time_fmts.cc)
+add_library(lnavdt STATIC ${CMAKE_BINARY_DIR}/src/config.h ptimec.hh ptimec_spec.hh ptimec_rt.cc time_fmts.cc)
 target_include_directories(lnavdt PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}
@@ -512,7 +512,7 @@ target_link_libraries(lnavfileio cppfmt spookyhash pcrepp base BZip2::BZip2 ZLIB
 add_library(
         diag STATIC
         ${GEN_SRCS}
-        config.h.in
+        ${CMAKE_BINARY_DIR}/src/config.h
         all_logs_vtab.cc
         apps.cc
         archive_manager.cc

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(
         base STATIC
-        ../config.h.in
+        ${CMAKE_BINARY_DIR}/src/config.h
         ansi_scrubber.cc
         attr_line.cc
         attr_line.builder.cc

--- a/src/base/result.h
+++ b/src/base/result.h
@@ -11,11 +11,11 @@
 
 #pragma once
 
+#include <cstdlib>
+#include <cstdio>
 #include <exception>
 #include <functional>
 #include <type_traits>
-
-#include <stdio.h>
 
 namespace types {
 template<typename T>
@@ -818,7 +818,7 @@ struct Result {
     {
         if (!isOk()) {
             ::fprintf(stderr, "%s\n", str);
-            abort();
+            std::abort();
         }
         return expect_impl(std::is_same<T, void>());
     }

--- a/src/pcrepp/CMakeLists.txt
+++ b/src/pcrepp/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_library(pcrepp STATIC
-        ../config.h.in
+        ${CMAKE_BINARY_DIR}/src/config.h
         pcre2pp.hh
         pcre2pp_fwd.hh
         pcre2pp.cc)
 
 target_include_directories(pcrepp PUBLIC . .. ../third-party/scnlib/include
         ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_link_libraries(pcrepp cppfmt PCRE2::8BIT PCRE2::16BIT PCRE2::32BIT PCRE2::POSIX)
+target_link_libraries(pcrepp cppfmt pcre2::pcre2)
 
 add_executable(test_pcre2pp test_pcre2pp.cc)
 target_include_directories(

--- a/src/remote/CMakeLists.txt
+++ b/src/remote/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(remote STATIC ../config.h.in remote.ssh.cc remote.ssh.hh)
+add_library(remote STATIC ${CMAKE_BINARY_DIR}/src/config.h remote.ssh.cc remote.ssh.hh)
 
 target_include_directories(remote PUBLIC . .. ../fmtlib
         ${CMAKE_CURRENT_BINARY_DIR}/..)

--- a/src/yajlpp/CMakeLists.txt
+++ b/src/yajlpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(
         yajlpp STATIC
-        ../config.h.in
+        ${CMAKE_BINARY_DIR}/src/config.h
         json_op.hh
         json_ptr.hh
         yajlpp.hh
@@ -16,6 +16,7 @@ target_include_directories(yajlpp PUBLIC . .. ../fmtlib
         ../third-party
 )
 target_link_libraries(yajlpp
+        base
         pcrepp
         yajl
         ${CURSES_LIBRARIES}
@@ -23,15 +24,15 @@ target_link_libraries(yajlpp
 )
 
 add_executable(test_yajlpp test_yajlpp.cc)
-target_link_libraries(test_yajlpp yajlpp base ${lnav_LIBS})
+target_link_libraries(test_yajlpp yajlpp)
 add_test(NAME test_yajlpp COMMAND test_yajlpp)
 
 add_executable(test_json_ptr test_json_ptr.cc)
-target_link_libraries(test_json_ptr yajlpp base ${lnav_LIBS})
+target_link_libraries(test_json_ptr yajlpp)
 add_test(NAME test_json_ptr COMMAND test_json_ptr)
 
 add_executable(drive_json_op drive_json_op.cc)
-target_link_libraries(drive_json_op base yajlpp ${lnav_LIBS})
+target_link_libraries(drive_json_op yajlpp)
 
 add_executable(drive_json_ptr_walk drive_json_ptr_walk.cc)
-target_link_libraries(drive_json_ptr_walk base yajlpp ${lnav_LIBS})
+target_link_libraries(drive_json_ptr_walk yajlpp)


### PR DESCRIPTION
CMake can now build using system libraries instead of depending on vcpkg. I'll try adding a github workflow for cmake builds in a later PR.

Tested with my system dependencies

cmake

```
-- Found PkgConfig: /usr/bin/pkg-config (found version "2.5.1")
-- Found SQLite3: /usr/lib/libsqlite3.so (found version "3.53.3")
-- Found BZip2: /usr/lib/libbz2.so (found version "1.0.8")
-- Looking for BZ2_bzCompressInit
-- Looking for BZ2_bzCompressInit - found
-- Found LibArchive: /usr/lib/libarchive.so (found version "3.8.8")
-- Found ZLIB: /usr/lib/libz.so (found version "1.3.2")
-- Checking for one of the modules 'libpcre2-8;libpcre2-16;libpcre2-32;libpcre2-posix'
-- Found CURL: /usr/lib/libcurl.so (found version "8.21.0")
-- Found Unistring: /usr/lib/libunistring.so
```

ldd

```
lnav (interpreter => /lib64/ld-linux-x86-64.so.2)
    libcurl.so.4 => /usr/lib/libcurl.so.4
        ...
    libsqlite3.so.0 => /usr/lib/libsqlite3.so.0
    libbz2.so.1.0 => /usr/lib/libbz2.so.1.0
    libpcre2-8.so.0 => /usr/lib/libpcre2-8.so.0
    libarchive.so.13 => /usr/lib/libarchive.so.13
        libacl.so.1 => /usr/lib/libacl.so.1
        liblz4.so.1 => /usr/lib/liblz4.so.1
        liblzma.so.5 => /usr/lib/liblzma.so.5
        libxml2.so.16 => /usr/lib/libxml2.so.16
            libicuuc.so.78 => /usr/lib/libicuuc.so.78
                libicudata.so.78 => /usr/lib/libicudata.so.78
    libz.so.1 => /usr/lib/libz.so.1
    libunistring.so.5 => /usr/lib/libunistring.so.5
    libstdc++.so.6 => /usr/lib/libstdc++.so.6
    libm.so.6 => /usr/lib/libm.so.6
    libgcc_s.so.1 => /usr/lib/libgcc_s.so.1
    libc.so.6 => /usr/lib/libc.so.6
    ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2
```