### PR TITLE
[laravel_log] support hyphenated channels

### DIFF
--- a/src/formats/laravel_log.json
+++ b/src/formats/laravel_log.json
@@ -8,7 +8,7 @@
         ],
         "regex": {
             "std": {
-                "pattern": "^\\[(?<timestamp>[\\d\\-:\\s]+)\\]\\s(?<env>\\w+)\\.(?<level>DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY):\\s(?<body>.*?)(?:\\s(?<context>\\{.*\\}|\\[.*\\])\\s*)?$"
+                "pattern": "^\\[(?<timestamp>[\\d\\-:\\s]+)\\]\\s(?<env>[\\w-]+)\\.(?<level>DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY):\\s(?<body>.*?)(?:\\s(?<context>\\{.*\\}|\\[.*\\])\\s*)?$"
             }
         },
         "value": {
@@ -32,6 +32,9 @@
             },
             {
                 "line": "[2025-08-31 12:34:56] local.ERROR: Something bad happened {\"user_id\":123,\"ip\":\"127.0.0.1\"}"
+            },
+            {
+                "line": "[2026-07-16 10:17:45] payment-systems.ERROR: Failed to process payment"
             }
         ]
     }


### PR DESCRIPTION
Fixes #1724

## Summary

- allow hyphenated Laravel/Monolog channel names such as `payment-systems`
- add a built-in format sample that keeps the reported channel shape under regression coverage

The Laravel format previously captured the channel with `\w+`, so a hyphen prevented the entire line from matching and the `ERROR` level was never parsed.

## Validation

- `jq empty src/formats/laravel_log.json`
- `git diff --check`
- confirmed the original PCRE rejects `[2026-07-16 10:17:45] payment-systems.ERROR: Failed to process payment`
- loaded the modified format through the official lnav 0.14.0 binary and queried `laravel_log`; `local`, `payment-systems`, and `user_settings` parsed respectively as `info`, `error`, and `warning`

A full source build was not run locally because this checkout does not have the complete native build dependency set. Upstream CI remains the authoritative full build and test gate.

## AI assistance

OpenAI Codex (GPT-5) identified the regex boundary, prepared the focused change, and ran the validation listed above. No human review is claimed.