### PR TITLE
fix: parse an epoch timestamp of exactly zero

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -118,6 +118,10 @@ Bug Fixes:
 * In a JSON-lines format definition, if a
   `line-format` contained a line-feed, fix
   highlighting of fields.
+* An epoch timestamp of exactly zero is now parsed
+  as 1970-01-01T00:00:00Z instead of being treated as
+  a parse failure.  Affects the `%s`, `%i`, `%6`,
+  `%9`, and `%q` conversions (issue #1586).
 
 
 ## lnav v0.14.0

--- a/src/ptimec.hh
+++ b/src/ptimec.hh
@@ -357,7 +357,7 @@ ptime_s(struct exttm* dst, const char* str, off_t& off_inout, ssize_t len)
         | ETF_MINUTE_SET | ETF_SECOND_SET | ETF_MACHINE_ORIENTED
         | ETF_EPOCH_TIME | ETF_ZONE_SET;
 
-    return (epoch > 0);
+    return (off_inout > off_start);
 }
 
 inline void
@@ -415,7 +415,7 @@ ptime_q(struct exttm* dst, const char* str, off_t& off_inout, ssize_t len)
         | ETF_MINUTE_SET | ETF_SECOND_SET | ETF_MACHINE_ORIENTED
         | ETF_EPOCH_TIME | ETF_ZONE_SET;
 
-    return (epoch > 0);
+    return (off_inout > off_start);
 }
 
 inline void
@@ -536,6 +536,7 @@ ftime_H(char* dst, off_t& off_inout, ssize_t len, const struct exttm& tm)
 inline bool
 ptime_i(struct exttm* dst, const char* str, off_t& off_inout, ssize_t len)
 {
+    off_t off_start = off_inout;
     uint64_t epoch_ms = 0;
     lnav::time64_t epoch;
 
@@ -558,7 +559,7 @@ ptime_i(struct exttm* dst, const char* str, off_t& off_inout, ssize_t len)
         | ETF_MACHINE_ORIENTED | ETF_EPOCH_TIME | ETF_ZONE_SET
         | ETF_SUB_NOT_IN_FORMAT;
 
-    return (epoch_ms > 0);
+    return (off_inout > off_start);
 }
 
 inline void
@@ -574,6 +575,7 @@ ftime_i(char* dst, off_t& off_inout, ssize_t len, const struct exttm& tm)
 inline bool
 ptime_6(struct exttm* dst, const char* str, off_t& off_inout, ssize_t len)
 {
+    off_t off_start = off_inout;
     uint64_t epoch_us = 0;
     lnav::time64_t epoch;
 
@@ -596,7 +598,7 @@ ptime_6(struct exttm* dst, const char* str, off_t& off_inout, ssize_t len)
         | ETF_MACHINE_ORIENTED | ETF_EPOCH_TIME | ETF_ZONE_SET
         | ETF_SUB_NOT_IN_FORMAT | ETF_Z_FOR_UTC;
 
-    return (epoch_us > 0);
+    return (off_inout > off_start);
 }
 
 inline void
@@ -612,6 +614,7 @@ ftime_6(char* dst, off_t& off_inout, ssize_t len, const struct exttm& tm)
 inline bool
 ptime_9(struct exttm* dst, const char* str, off_t& off_inout, ssize_t len)
 {
+    off_t off_start = off_inout;
     uint64_t epoch_ns = 0;
     lnav::time64_t epoch;
 
@@ -633,7 +636,7 @@ ptime_9(struct exttm* dst, const char* str, off_t& off_inout, ssize_t len)
         | ETF_MINUTE_SET | ETF_SECOND_SET | ETF_NANOS_SET | ETF_MACHINE_ORIENTED
         | ETF_EPOCH_TIME | ETF_ZONE_SET | ETF_SUB_NOT_IN_FORMAT | ETF_Z_FOR_UTC;
 
-    return (epoch_ns > 0);
+    return (off_inout > off_start);
 }
 
 inline void

--- a/test/test_date_time_scanner.cc
+++ b/test/test_date_time_scanner.cc
@@ -354,4 +354,37 @@ TEST_CASE("date_time_scanner")
         assert(rc == 19);
         assert(strcmp(ts, buf) == 0);
     }
+
+    {
+        // issue #1586: an epoch timestamp of exactly zero is valid
+        const char* epoch_fmts[]
+            = {"ts %s ]", "ts %i ]", "ts %6 ]", "ts %9 ]", "ts %q ]"};
+
+        for (const auto* fmt : epoch_fmts) {
+            const char* epoch_str = "ts 0 ]";
+            exttm tm;
+            off_t off = 0;
+
+            memset(&tm, 0, sizeof(tm));
+            bool rc = ptime_fmt(fmt, &tm, epoch_str, off, strlen(epoch_str));
+            CHECK(rc);
+            CHECK(tm2sec(&tm.et_tm) == 0);
+            CHECK(tm.et_nsec == 0);
+        }
+    }
+
+    {
+        // an epoch field with no digits is still a parse failure
+        const char* epoch_fmts[]
+            = {"ts %s ]", "ts %i ]", "ts %6 ]", "ts %9 ]", "ts %q ]"};
+
+        for (const auto* fmt : epoch_fmts) {
+            const char* epoch_str = "ts x ]";
+            exttm tm;
+            off_t off = 0;
+
+            memset(&tm, 0, sizeof(tm));
+            CHECK(!ptime_fmt(fmt, &tm, epoch_str, off, strlen(epoch_str)));
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1586.

## The cause

The epoch parsers all end by reporting success based on the *value* rather than on whether they parsed anything:

```cpp
return (epoch > 0);
```

So a timestamp of exactly `0` — the unix epoch itself — is indistinguishable from "no digits here", and lnav rejects the line. Your "Huh, that's an odd one... some sanity check somewhere" was on the money; the sanity check is the return statement itself.

## The fix

Report success when digits were actually consumed:

```cpp
return (off_inout > off_start);
```

`off_start` was already declared in `ptime_s` and `ptime_q` for their overflow guards; `ptime_i`, `ptime_6` and `ptime_9` needed it added. The existing `epoch >= MAX_TIME_T` range guards are untouched, and a field with no digits still fails because the loop consumes nothing.

**`%q` is included.** The issue is about `%s`, but `ptime_q` (hex epoch) has the identical `return (epoch > 0)` and therefore the identical bug — a hex epoch of `0` fails to parse for the same reason. Fixing four of five would have left the same defect in the codebase, so I did all five. Say the word if you'd rather it were scoped down.

## Testing, and what I could not do

Being straight about this: **I could not run `make check`.** `autoconf`, `automake`, `cmake` and `pkg-config` are all absent from my environment — only `g++` is available.

What I did instead was compile the *real* `src/ptimec.hh` and `src/ptimec_rt.cc` against the repo's own `third-party/date` headers, with small stubs for `config.h`, `lnav_log.hh` and the three out-of-line time helpers, and exercise the five functions directly:

```
                              patched      unpatched
ptime_s   "0"                 true  ok     false  FAIL
ptime_i   "0"                 true  ok     false  FAIL
ptime_6   "0"                 true  ok     false  FAIL
ptime_9   "0"                 true  ok     false  FAIL
ptime_q   "0"                 true  ok     false  FAIL
ptime_s   "x"                 false ok     false  ok
ptime_q   "z"                 false ok     false  ok
ptime_s   ""                  false ok     false  ok
ptime_s 1428721664            true  ok     true   ok
ptime_q hex 5527ad80          true  ok     true   ok
```

5 failures before, 0 after, with the non-digit and normal-value cases unchanged in both directions.

Test cases are added to `test/test_date_time_scanner.cc` in the existing style: one asserting all five conversions parse `0` to epoch zero, one asserting a digit-less field is still a failure. (`x` is not a hex digit, so it's a valid negative case for `%q` too — I checked.)

A NEWS.md entry is added under `## lnav v0.14.1`.

The full doctest suite and any end-to-end log-file test remain unrun on my side.

## Callers

`ptime_fmt` in `src/ptimec_rt.cc` is the only dispatcher and just propagates the boolean; its only in-tree consumer is `src/log_format.cc:3993`. `date_time_scanner.cc` has no zero-value special case. Nothing depended on 0-means-failure.
