### PR TITLE
[listview] restore scrolling to the top on a second G/End

### DIFF
--- a/src/listview_curses.cc
+++ b/src/listview_curses.cc
@@ -421,7 +421,16 @@ listview_curses::handle_key(const ncinput& ch)
             auto tail_bottom = this->get_top_for_last_row();
 
             if (this->is_selectable()) {
-                this->set_selection(last_line);
+                auto sel = this->get_selection();
+                if (sel && sel.value() == last_line
+                    && this->get_top() != last_line)
+                {
+                    // Already on the last line, so scroll it up to the top,
+                    // matching the behavior in non-cursor mode.
+                    this->set_top(last_line);
+                } else {
+                    this->set_selection(last_line);
+                }
             } else if (this->get_top() == last_line) {
                 this->set_top(tail_bottom);
             } else if (tail_bottom <= this->get_top()) {


### PR DESCRIPTION
Fixes #1734.

The second press logic only ever existed in the non-selectable branch of the `G`/`NCKEY_END` case:

```cpp
if (this->is_selectable()) {
    this->set_selection(last_line);      // stops here
} else if (this->get_top() == last_line) {
    this->set_top(tail_bottom);
} else if (tail_bottom <= this->get_top()) {
    this->set_top(last_line);            // the "press again" step
} else {
    this->set_top(tail_bottom);
}
```

The block itself has not changed. What changed is around it: 7fa4e253 made cursor mode the default, cursor mode calls `set_selectable(true)` on the main views, and from then on every press takes the first branch and stops after moving the selection.

This gives the selectable branch the same second stage, guarded so it does nothing when the last line is already at the top.

Measured on a 200 line syslog file in an 80x24 terminal, pressing `g` then `G` then `G` and reading back the first visible line:

| | after `g` | first `G` | second `G` |
| --- | --- | --- | --- |
| master, cursor mode | 000 | 183 | 183 |
| this patch, cursor mode | 000 | 183 | 198 |
| master, `movement/mode top` | 000 | 183 | 198 |

So cursor mode now lands on exactly what the old path did, down to the 198 rather than 199, which comes from the view tail space.

One note on reproducing: I only saw the stuck behavior after passing `-c ":config /ui/movement/mode cursor"` explicitly. Without it my build behaved like top mode, so the reload delegate that flips the views to selectable did not appear to run on a plain startup here. That may be worth a separate look, but it is not what this patch touches.

`get_selection()` returns an optional, so the check goes through `has_value` rather than comparing the optional directly. Builds clean, and the only warning in `listview_curses.cc` is the pre-existing sign-compare at `ov_sel >= count`.